### PR TITLE
chore: Spring Actuator 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,18 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
+
+    runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,3 +2,16 @@ spring:
   application:
     name: stonebed
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+      base-path: /walwal-actuator
+    jmx:
+      exposure:
+        exclude: "*"
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true


### PR DESCRIPTION
## 🌱 관련 이슈
- close #3 

## 📌 작업 내용
- Spring Actuator 구성
- `/walwal-actuator/health`로 health 체크
- 액추에이터 관련 보안 설정을 적용
- jmx 방식은 모든 endpoint를 사용하므로 비활성화
- health 관련 엔드포인트만 활성화

## 🙏 리뷰 요구사항
- `application.yml`에 옵션까지 작업 내용에 설명하였습니다!

## 📚 레퍼런스
- https://techblog.woowahan.com/9232/