### PR TITLE
[WALWAL-96] SwaggerConfig 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     // Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	compileOnly 'org.projectlombok:lombok'
 
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/depromeet/stonebed/global/config/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/stonebed/global/config/SwaggerConfig.java
@@ -1,13 +1,19 @@
 package com.depromeet.stonebed.global.config;
 
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 
 @Configuration
 public class SwaggerConfig {
+	private static final String packagesToScan = "com.depromeet.stonebed";
+
+	@Value("${api.version}")
+	private String apiVersion;
 
 	// OpenAPI Bean 설정
 	@Bean
@@ -15,17 +21,14 @@ public class SwaggerConfig {
 		return new OpenAPI()
 			.info(new Info()
 				.title("WalWal 프로젝트 API 문서화")
-				.version("1.0")
+				.version(apiVersion)
 				.description("WalWal 프로젝트의 Swagger UI 화면입니다."));
 	}
 
 	// GroupedOpenApi Bean 설정
 	@Bean
 	public GroupedOpenApi groupedOpenApi() {
-		String[] paths = {"/api/v1/**"};
-		String[] packagesToScan = {"com.depromeet.stonebed"};
 		return GroupedOpenApi.builder().group("WalWal API")
-			.pathsToMatch(paths)
 			.packagesToScan(packagesToScan)
 			.build();
 	}

--- a/src/main/java/com/depromeet/stonebed/global/config/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/stonebed/global/config/SwaggerConfig.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.models.info.Info;
 
 @Configuration
 public class SwaggerConfig {
-	private static final String packagesToScan = "com.depromeet.stonebed";
+	private static final String PACKAGES_TO_SCAN = "com.depromeet.stonebed";
 
 	@Value("${api.version}")
 	private String apiVersion;
@@ -29,7 +29,7 @@ public class SwaggerConfig {
 	@Bean
 	public GroupedOpenApi groupedOpenApi() {
 		return GroupedOpenApi.builder().group("WalWal API")
-			.packagesToScan(packagesToScan)
+			.packagesToScan(PACKAGES_TO_SCAN)
 			.build();
 	}
 }

--- a/src/main/java/com/depromeet/stonebed/global/config/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/stonebed/global/config/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package com.depromeet.stonebed.global.config;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class SwaggerConfig {
+
+	// OpenAPI Bean 설정
+	@Bean
+	public OpenAPI openAPI() {
+		return new OpenAPI()
+			.info(new Info()
+				.title("WalWal 프로젝트 API 문서화")
+				.version("1.0")
+				.description("WalWal 프로젝트의 Swagger UI 화면입니다."));
+	}
+
+	// GroupedOpenApi Bean 설정
+	@Bean
+	public GroupedOpenApi groupedOpenApi() {
+		String[] paths = {"/api/v1/**"};
+		String[] packagesToScan = {"com.depromeet.stonebed"};
+		return GroupedOpenApi.builder().group("WalWal API")
+			.pathsToMatch(paths)
+			.packagesToScan(packagesToScan)
+			.build();
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,18 @@ management:
   endpoint:
     health:
       enabled: true
+
+springdoc:
+  api-docs:
+    path: /api-docs
+    groups:
+      enabled: true
+  swagger-ui:
+    enabled: true
+    groups-order: ASC
+    tags-sorter: alpha
+    operations-sorter: alpha
+    display-request-duration: true
+    doc-expansion: none
+  cache:
+    disabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,6 @@ springdoc:
     doc-expansion: none
   cache:
     disabled: true
+
+api:
+  version: "0.0.1"


### PR DESCRIPTION
## 🌱 관련 이슈
- close #13 

## 📌 작업 내용
- Springdoc + Swagger 프로젝트 기본 설정
- Springdoc-openapi-v2.3.0

## 🙏 리뷰 요구사항
- springfox 라이브러리 업데이트 종료로 인해 SpringBoot 3.x.x버전에서 사용에 용이한 Springdoc-openapi-v2 이상 사용권장. 
- 아직 API 문서 인증(Authroize) 기능은 설정하지 않았습니다. 추후에 Security 설정하고 JWT토큰을 통한 인증과정 추가하겠습니다.

## 📚 레퍼런스
- https://blog.naver.com/seek316/223349824088
- https://wonsjung.tistory.com/584
