### PR TITLE
[WALWAL-84] jacoco 세팅 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'org.springframework.boot' version '3.2.6'
 	id 'io.spring.dependency-management' version '1.1.5'
     id 'com.diffplug.spotless' version '6.21.0'
+    id 'jacoco'
 }
 
 group = 'com.depromeet'
@@ -46,6 +47,45 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+def jacocoExcludePatterns = [
+        '**/*Application*',
+        '**/test/**'
+]
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+        csv.required.set(true)
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: jacocoExcludePatterns)
+                })
+        )
+    }
+
+    finalizedBy jacocoTestCoverageVerification
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+            excludes = jacocoExcludePatterns
+        }
+    }
 }
 
 spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -54,23 +54,36 @@ jacoco {
     toolVersion = "0.8.12"
 }
 
+def QDomains = []
+
+for (qPattern in '*/QA'..'*/QZ') {
+    QDomains.add(qPattern + '*')
+}
+
 def jacocoExcludePatterns = [
         '**/*Application*',
-        '**/test/**'
+        '**/*Config/*',
+        '**/resources/**',
+        '**/test/**',
 ]
+
+def jacocoDir = layout.buildDirectory.dir("reports/")
 
 jacocoTestReport {
     dependsOn test
     reports {
-        xml.required.set(true)
         html.required.set(true)
+        xml.required.set(true)
         csv.required.set(true)
+        html.destination jacocoDir.get().file("jacoco/html").asFile
+        xml.destination jacocoDir.get().file("jacoco/index.xml").asFile
+        csv.destination jacocoDir.get().file("jacoco/index.csv").asFile
     }
 
     afterEvaluate {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
-                    fileTree(dir: it, excludes: jacocoExcludePatterns)
+                    fileTree(dir: it, excludes: jacocoExcludePatterns + QDomains)
                 })
         )
     }
@@ -83,7 +96,7 @@ jacocoTestCoverageVerification {
         rule {
             enabled = true
             element = 'CLASS'
-            excludes = jacocoExcludePatterns
+            excludes = jacocoExcludePatterns + QDomains
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #6

## 📌 작업 내용
- Code Coverage Dependancy 추가
  - `test` 작업 이후 실행되도록 설정
  - 메인 Application, test 파일들은 카운팅에서 제외

## 🙏 리뷰 요구사항
- 추가로 필터링하면 좋을 옵션들을 알려주시면 좋을 것 같아요.
- 사소한 변수명이나 Coverage reports의 저장 경로같은 경우도 의견을 듣고 싶어요

## 📚 레퍼런스
- [jacoco - Mission](https://www.jacoco.org/jacoco/trunk/doc/mission.html)
- [gradle - JacocoReport](https://docs.gradle.org/current/dsl/org.gradle.testing.jacoco.tasks.JacocoReport.html)
- [gradle - JacocoCoverageVerification](https://docs.gradle.org/current/dsl/org.gradle.testing.jacoco.tasks.JacocoCoverageVerification.html)
- [우아한 기술블로그 - Gradle 프로젝트에 JaCoCo 설정하기](https://techblog.woowahan.com/2661/)
- [윤범님 블로그 - [Spring boot] Jacoco + Sonarcloud 로 코드 커버리지 분석하기](https://velog.io/@uiurihappy/Spring-Jacoco-Sonarcloud-%EB%A1%9C-%EC%BD%94%EB%93%9C-%EB%B6%84%EC%84%9D%ED%95%98%EA%B8%B0)
