### PR TITLE
[WALWAL-107] BaseTimeEntity 추가

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/depromeet/stonebed/domain/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.depromeet.stonebed.domain.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @Column(updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column @LastModifiedDate private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/depromeet/stonebed/global/config/jpa/JpaConfig.java
+++ b/src/main/java/com/depromeet/stonebed/global/config/jpa/JpaConfig.java
@@ -1,0 +1,8 @@
+package com.depromeet.stonebed.global.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #21 

## 📌 작업 내용
- BaseTimeEntity 추가로 createdAt과 updatedAt을 상속받아 Entity 구성할 수 있도록 구현
- EnableJpaAuditing는 별도의 config로 분리하여 관리

## 🙏 리뷰 요구사항
-

## 📚 레퍼런스
- 
