### PR TITLE
[WALWAL-106] fixtureMonkey 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 *.env
 *.DS_Store
 /src/main/generated
+.*-database

--- a/build.gradle
+++ b/build.gradle
@@ -36,17 +36,25 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	compileOnly 'org.projectlombok:lombok'
 
+    // Database
     runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Lombok
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // Test Lombok
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    // FixtureMonkey
+    testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.20")
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+    jvmArgs '-Xshare:off' // JVM 아규먼트 설정
     finalizedBy jacocoTestReport
 }
 

--- a/src/main/java/com/depromeet/stonebed/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/depromeet/stonebed/domain/common/BaseTimeEntity.java
@@ -1,15 +1,13 @@
 package com.depromeet.stonebed.domain.common;
 
-import java.time.LocalDateTime;
-
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    group:
+      test: "test"
   application:
     name: stonebed
 

--- a/src/test/java/com/depromeet/stonebed/fixtureMonkeyTest/Order.java
+++ b/src/test/java/com/depromeet/stonebed/fixtureMonkeyTest/Order.java
@@ -1,0 +1,43 @@
+package com.depromeet.stonebed.fixtureMonkeyTest;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class Order {
+    @NotNull private Long id;
+
+    @NotBlank private String orderNo;
+
+    private OrderType orderType;
+
+    @Size(min = 2, max = 10)
+    private String productName;
+
+    @Min(1)
+    @Max(100)
+    private int quantity;
+
+    @Min(0)
+    private long price;
+
+    private long totalPrice;
+
+    private List<@NotBlank @Size(max = 10) String> items = new ArrayList<>();
+
+    @PastOrPresent private Instant orderedAt;
+
+    public enum OrderType {
+        SMARTSTORE,
+        BLOG,
+        CAFE,
+    }
+}

--- a/src/test/java/com/depromeet/stonebed/fixtureMonkeyTest/TestFixtureMonkey.java
+++ b/src/test/java/com/depromeet/stonebed/fixtureMonkeyTest/TestFixtureMonkey.java
@@ -54,7 +54,7 @@ class TestFixtureMonkey {
                                         .ofMaxLength(10)
                                         .list()
                                         .ofMinSize(1)
-                                        .ofMaxSize(3))
+                                        .ofMaxSize(2))
                         .sample();
 
         // then

--- a/src/test/java/com/depromeet/stonebed/fixtureMonkeyTest/TestFixtureMonkey.java
+++ b/src/test/java/com/depromeet/stonebed/fixtureMonkeyTest/TestFixtureMonkey.java
@@ -1,0 +1,69 @@
+package com.depromeet.stonebed.fixtureMonkeyTest;
+
+import static org.assertj.core.api.BDDAssertions.*;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import net.jqwik.api.Arbitraries;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TestFixtureMonkey {
+
+    @Test
+    void checkPerson() {
+        // given
+        FixtureMonkey sut =
+                FixtureMonkey.builder()
+                        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+                        .defaultNotNull(true)
+                        .build();
+
+        // when
+        User person =
+                sut.giveMeBuilder(User.class)
+                        .set("age", Arbitraries.integers().between(1, 100))
+                        .set("personNo", Arbitraries.strings().ofMinLength(1).ofMaxLength(16))
+                        .sample();
+
+        // then
+        then(person.getPersonId()).isNotNull();
+        then(person.getPersonName()).isNotBlank();
+        then(person.getPersonNo().length()).isBetween(1, 16);
+    }
+
+    @Test
+    void testOrder() {
+        // given
+        FixtureMonkey sut =
+                FixtureMonkey.builder()
+                        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+                        .defaultNotNull(true)
+                        .build();
+
+        // when
+        Order actual =
+                sut.giveMeBuilder(Order.class)
+                        .set("productName", Arbitraries.strings().ofMinLength(2).ofMaxLength(10))
+                        .set("price", Arbitraries.longs().between(0, 1000))
+                        .set("quantity", Arbitraries.integers().between(1, 100))
+                        .set(
+                                "items",
+                                Arbitraries.strings()
+                                        .ofMaxLength(10)
+                                        .list()
+                                        .ofMinSize(1)
+                                        .ofMaxSize(3))
+                        .sample();
+
+        // then
+        then(actual.getId()).isNotNull(); // @NotNull
+        then(actual.getOrderNo()).isNotBlank(); // @NotBlank
+        then(actual.getProductName().length()).isBetween(2, 10); // @Size(min = 2, max = 10)
+        then(actual.getQuantity()).isBetween(1, 100); // Min(1) @Max(100)
+        then(actual.getPrice()).isGreaterThanOrEqualTo(0); // @Min(0)
+        then(actual.getItems()).hasSizeLessThan(3); // @Size(max = 3)
+        then(actual.getItems()).allMatch(it -> it.length() <= 10); // @NotBlank @Size(max = 10)
+    }
+}

--- a/src/test/java/com/depromeet/stonebed/fixtureMonkeyTest/User.java
+++ b/src/test/java/com/depromeet/stonebed/fixtureMonkeyTest/User.java
@@ -1,0 +1,30 @@
+package com.depromeet.stonebed.fixtureMonkeyTest;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class User {
+
+    @NotNull private String personId;
+
+    @NotBlank private String personName;
+
+    private Gender gender;
+
+    @Size(min = 1, max = 16)
+    private String personNo;
+
+    @Size(min = 1, max = 16)
+    private int age;
+
+    private List<String> addressList;
+
+    public enum Gender {
+        MAN,
+        WOMAN
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,12 @@
+spring:
+  config:
+    activate:
+      on-profile: "test"
+
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000


### PR DESCRIPTION
## 🌱 관련 이슈
- close #18 

## 📌 작업 내용
- fixtureMonkey 도입
- 테스트 `@Data` 클래스를 생성하여 진행
- fixtureMonkey 객체 생성 시 파라미터 set을 해야 한다.

## 🙏 리뷰 요구사항
-

## 📚 레퍼런스
- [올리브영 fixtureMonkey 도입기](https://oliveyoung.tech/blog/2024-04-01/testcode-use-fixture-monkey/)
- [deview 레퍼런스](https://deview.kr/data/deview/session/attach/11_%ED%85%8C%EC%8A%A4%ED%8A%B8%20%EA%B0%9D%EC%B2%B4%EB%8A%94%20%EC%97%A3%EC%A7%80%20%EC%BC%80%EC%9D%B4%EC%8A%A4%EA%B9%8C%EC%A7%80%20%EC%B0%BE%EC%95%84%EC%A3%BC%EB%8A%94%20Fixture%20Monkey%EC%97%90%EA%B2%8C%20%EB%A7%A1%EA%B8%B0%EC%84%B8%EC%9A%94.pdf)
- [랜덤 데이터 생성 라이브러리](https://velog.io/@phdljr/TIL-FixtureMonkey-%EB%9E%9C%EB%8D%A4-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%83%9D%EC%84%B1-%EB%9D%BC%EC%9D%B4%EB%B8%8C%EB%9F%AC%EB%A6%AC)
