### PR TITLE
[WALWAL-147] 오늘의 미션 API 추가

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/mission/api/MissionController.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/api/MissionController.java
@@ -5,6 +5,7 @@ import com.depromeet.stonebed.domain.mission.dto.request.MissionCreateRequest;
 import com.depromeet.stonebed.domain.mission.dto.request.MissionUpdateRequest;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionCreateResponse;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionGetOneResponse;
+import com.depromeet.stonebed.domain.mission.dto.response.MissionGetTodayResponse;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionUpdateResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -22,6 +23,11 @@ public class MissionController {
     public MissionCreateResponse createMission(
             @Valid @RequestBody MissionCreateRequest missionCreateRequest) {
         return missionService.createMission(missionCreateRequest);
+    }
+
+    @GetMapping("/today")
+    public MissionGetTodayResponse getTodayMission() {
+        return missionService.getOrCreateTodayMission();
     }
 
     @GetMapping("/{missionId}")

--- a/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
@@ -1,14 +1,21 @@
 package com.depromeet.stonebed.domain.mission.application;
 
+import com.depromeet.stonebed.domain.mission.dao.MissionHistoryRepository;
 import com.depromeet.stonebed.domain.mission.dao.MissionRepository;
 import com.depromeet.stonebed.domain.mission.domain.Mission;
+import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
 import com.depromeet.stonebed.domain.mission.dto.request.MissionCreateRequest;
 import com.depromeet.stonebed.domain.mission.dto.request.MissionUpdateRequest;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionCreateResponse;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionGetOneResponse;
+import com.depromeet.stonebed.domain.mission.dto.response.MissionGetTodayResponse;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionUpdateResponse;
 import com.depromeet.stonebed.global.error.ErrorCode;
 import com.depromeet.stonebed.global.error.exception.CustomException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MissionService {
     private final MissionRepository missionRepository;
+    private final MissionHistoryRepository missionHistoryRepository;
+    private final Random random = new Random();
 
     public MissionCreateResponse createMission(MissionCreateRequest missionCreateRequest) {
         Mission mission = Mission.builder().title(missionCreateRequest.title()).build();
@@ -32,6 +41,41 @@ public class MissionService {
                 .findById(missionId)
                 .map(MissionGetOneResponse::from)
                 .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
+    }
+
+    @Transactional
+    public MissionGetTodayResponse getOrCreateTodayMission() {
+        LocalDate today = LocalDate.now();
+        Optional<MissionHistory> optionalMissionHistory =
+                missionHistoryRepository.findByAssignedDate(today);
+
+        if (optionalMissionHistory.isPresent()) {
+            return MissionGetTodayResponse.from(optionalMissionHistory.get().getMission());
+        }
+
+        LocalDate threeDaysAgo = LocalDate.now().minusDays(3);
+
+        List<MissionHistory> recentMissionHistories =
+                missionHistoryRepository.findByAssignedDateBefore(threeDaysAgo);
+        List<Long> recentMissionIds =
+                recentMissionHistories.stream()
+                        .map(history -> history.getMission().getId())
+                        .toList();
+
+        List<Mission> availableMissions = missionRepository.findAllByIdNotIn(recentMissionIds);
+
+        if (availableMissions.isEmpty()) {
+            throw new CustomException(ErrorCode.NO_AVAILABLE_TODAY_MISSION);
+        }
+
+        Mission selectedMission = availableMissions.get(random.nextInt(availableMissions.size()));
+
+        MissionHistory newMissionHistory =
+                MissionHistory.builder().mission(selectedMission).assignedDate(today).build();
+
+        missionHistoryRepository.save(newMissionHistory);
+
+        return MissionGetTodayResponse.from(selectedMission);
     }
 
     public MissionUpdateResponse updateMission(

--- a/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
@@ -53,7 +53,7 @@ public class MissionService {
             return MissionGetTodayResponse.from(optionalMissionHistory.get().getMission());
         }
 
-        LocalDate threeDaysAgo = LocalDate.now().minusDays(3);
+        LocalDate threeDaysAgo = today.minusDays(3);
 
         List<MissionHistory> recentMissionHistories =
                 missionHistoryRepository.findByAssignedDateBefore(threeDaysAgo);
@@ -62,7 +62,7 @@ public class MissionService {
                         .map(history -> history.getMission().getId())
                         .toList();
 
-        List<Mission> availableMissions = missionRepository.findAllByIdNotIn(recentMissionIds);
+        List<Mission> availableMissions = missionRepository.findMissionsByIdNotIn(recentMissionIds);
 
         if (availableMissions.isEmpty()) {
             throw new CustomException(ErrorCode.NO_AVAILABLE_TODAY_MISSION);

--- a/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
@@ -12,10 +12,10 @@ import com.depromeet.stonebed.domain.mission.dto.response.MissionGetTodayRespons
 import com.depromeet.stonebed.domain.mission.dto.response.MissionUpdateResponse;
 import com.depromeet.stonebed.global.error.ErrorCode;
 import com.depromeet.stonebed.global.error.exception.CustomException;
+import java.security.SecureRandom;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MissionService {
     private final MissionRepository missionRepository;
     private final MissionHistoryRepository missionHistoryRepository;
-    private final Random random = new Random();
+    private final SecureRandom secureRandom = new SecureRandom();
 
     public MissionCreateResponse createMission(MissionCreateRequest missionCreateRequest) {
         Mission mission = Mission.builder().title(missionCreateRequest.title()).build();
@@ -68,7 +68,8 @@ public class MissionService {
             throw new CustomException(ErrorCode.NO_AVAILABLE_TODAY_MISSION);
         }
 
-        Mission selectedMission = availableMissions.get(random.nextInt(availableMissions.size()));
+        Mission selectedMission =
+                availableMissions.get(secureRandom.nextInt(availableMissions.size()));
 
         MissionHistory newMissionHistory =
                 MissionHistory.builder().mission(selectedMission).assignedDate(today).build();

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.depromeet.stonebed.domain.mission.dao;
+
+import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionHistoryRepository extends JpaRepository<MissionHistory, Long> {
+    Optional<MissionHistory> findByAssignedDate(LocalDate date);
+
+    List<MissionHistory> findByAssignedDateBefore(LocalDate date);
+}

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepository.java
@@ -1,6 +1,12 @@
 package com.depromeet.stonebed.domain.mission.dao;
 
 import com.depromeet.stonebed.domain.mission.domain.Mission;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface MissionRepository extends JpaRepository<Mission, Long> {}
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+    @Query("SELECT m FROM Mission m WHERE m.id NOT IN :mission_ids")
+    List<Mission> findAllByIdNotIn(@Param("mission_ids") List<Long> mission_ids);
+}

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepository.java
@@ -3,10 +3,7 @@ package com.depromeet.stonebed.domain.mission.dao;
 import com.depromeet.stonebed.domain.mission.domain.Mission;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface MissionRepository extends JpaRepository<Mission, Long> {
-    @Query("SELECT m FROM Mission m WHERE m.id NOT IN :mission_ids")
-    List<Mission> findAllByIdNotIn(@Param("mission_ids") List<Long> mission_ids);
+    List<Mission> findMissionsByIdNotIn(List<Long> mission_ids);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepository.java
@@ -5,5 +5,5 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissionRepository extends JpaRepository<Mission, Long> {
-    List<Mission> findMissionsByIdNotIn(List<Long> mission_ids);
+    List<Mission> findMissionsByIdNotIn(List<Long> missionIds);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepository.java
@@ -1,9 +1,6 @@
 package com.depromeet.stonebed.domain.mission.dao;
 
 import com.depromeet.stonebed.domain.mission.domain.Mission;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MissionRepository extends JpaRepository<Mission, Long> {
-    List<Mission> findMissionsByIdNotIn(List<Long> missionIds);
-}
+public interface MissionRepository extends JpaRepository<Mission, Long> {}

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepository.java
@@ -3,4 +3,4 @@ package com.depromeet.stonebed.domain.mission.dao;
 import com.depromeet.stonebed.domain.mission.domain.Mission;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MissionRepository extends JpaRepository<Mission, Long> {}
+public interface MissionRepository extends JpaRepository<Mission, Long>, MissionRepositoryCustom {}

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.depromeet.stonebed.domain.mission.dao;
+
+import com.depromeet.stonebed.domain.mission.domain.Mission;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MissionRepositoryCustom {
+    List<Mission> findNotInMissions(List<Mission> missions);
+
+    List<Mission> findMissionsAssignedBefore(LocalDate assignedDate);
+}

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.depromeet.stonebed.domain.mission.dao;
+
+import static com.depromeet.stonebed.domain.mission.domain.QMission.mission;
+import static com.depromeet.stonebed.domain.mission.domain.QMissionHistory.missionHistory;
+
+import com.depromeet.stonebed.domain.mission.domain.Mission;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MissionRepositoryImpl implements MissionRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Mission> findNotInMissions(List<Mission> missions) {
+        return queryFactory.selectFrom(mission).where(mission.notIn(missions)).fetch();
+    }
+
+    @Override
+    public List<Mission> findMissionsAssignedBefore(LocalDate assignedDate) {
+        return queryFactory
+                .select(missionHistory.mission)
+                .from(missionHistory)
+                .where(missionHistory.assignedDate.before(assignedDate))
+                .fetch();
+    }
+}

--- a/src/main/java/com/depromeet/stonebed/domain/mission/domain/MissionHistory.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/domain/MissionHistory.java
@@ -1,0 +1,32 @@
+package com.depromeet.stonebed.domain.mission.domain;
+
+import com.depromeet.stonebed.domain.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MissionHistory extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mission_history_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @Column(name = "assigned_date", nullable = false, unique = true)
+    private LocalDate assignedDate;
+
+    @Builder
+    public MissionHistory(Mission mission, LocalDate assignedDate) {
+        this.mission = mission;
+        this.assignedDate = assignedDate;
+    }
+}

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dto/response/MissionGetTodayResponse.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dto/response/MissionGetTodayResponse.java
@@ -1,0 +1,15 @@
+package com.depromeet.stonebed.domain.mission.dto.response;
+
+import com.depromeet.stonebed.domain.mission.domain.Mission;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record MissionGetTodayResponse(
+        @Schema(description = "미션 ID", example = "1") @NotBlank Long id,
+        @Schema(description = "미션 제목", example = "산책하기")
+                @NotBlank(message = "Title cannot be blank")
+                String title) {
+    public static MissionGetTodayResponse from(Mission mission) {
+        return new MissionGetTodayResponse(mission.getId(), mission.getTitle());
+    }
+}

--- a/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
+++ b/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
@@ -28,11 +28,13 @@ public enum ErrorCode {
     // mission
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션을 찾을 수 없습니다."),
     MISSION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션 기록을 찾을 수 없습니다."),
+	NO_AVAILABLE_TODAY_MISSION(HttpStatus.INTERNAL_SERVER_ERROR, "할당 가능한 오늘의 미션이 없습니다."),
 
     // image
     IMAGE_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이미지를 찾을 수 없습니다."),
     IMAGE_FILE_EXTENSION_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지 파일 확장자를 찾을 수 없습니다."),
-    INVALID_IMAGE_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "올바른 이미지 확장자가 아닙니다.");
+    INVALID_IMAGE_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "올바른 이미지 확장자가 아닙니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
+++ b/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
@@ -28,13 +28,12 @@ public enum ErrorCode {
     // mission
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션을 찾을 수 없습니다."),
     MISSION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션 기록을 찾을 수 없습니다."),
-	NO_AVAILABLE_TODAY_MISSION(HttpStatus.INTERNAL_SERVER_ERROR, "할당 가능한 오늘의 미션이 없습니다."),
+    NO_AVAILABLE_TODAY_MISSION(HttpStatus.INTERNAL_SERVER_ERROR, "할당 가능한 오늘의 미션이 없습니다."),
 
     // image
     IMAGE_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이미지를 찾을 수 없습니다."),
     IMAGE_FILE_EXTENSION_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지 파일 확장자를 찾을 수 없습니다."),
-    INVALID_IMAGE_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "올바른 이미지 확장자가 아닙니다.")
-    ;
+    INVALID_IMAGE_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "올바른 이미지 확장자가 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/depromeet/stonebed/domain/mission/api/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/api/MissionControllerTest.java
@@ -9,6 +9,7 @@ import com.depromeet.stonebed.domain.mission.dto.request.MissionCreateRequest;
 import com.depromeet.stonebed.domain.mission.dto.request.MissionUpdateRequest;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionCreateResponse;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionGetOneResponse;
+import com.depromeet.stonebed.domain.mission.dto.response.MissionGetTodayResponse;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionUpdateResponse;
 import com.depromeet.stonebed.global.common.response.ApiResponseAdvice;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +52,19 @@ public class MissionControllerTest {
                         post("/missions")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("{\"title\":\"Test Mission\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("Test Mission"));
+    }
+
+    @Test
+    public void testGetTodayMission() throws Exception {
+        // Given
+        MissionGetTodayResponse missionGetTodayResponse =
+                new MissionGetTodayResponse(1L, "Test Mission");
+        when(missionService.getOrCreateTodayMission()).thenReturn(missionGetTodayResponse);
+
+        // When & Then
+        mockMvc.perform(get("/missions/today"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.title").value("Test Mission"));
     }

--- a/src/test/java/com/depromeet/stonebed/domain/mission/api/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/api/MissionControllerTest.java
@@ -41,7 +41,7 @@ public class MissionControllerTest {
     }
 
     @Test
-    public void testCreateMission() throws Exception {
+    public void 미션_생성_성공() throws Exception {
         // Given
         MissionCreateResponse missionCreateResponse = new MissionCreateResponse(1L, "Test Mission");
         when(missionService.createMission(any(MissionCreateRequest.class)))
@@ -57,7 +57,7 @@ public class MissionControllerTest {
     }
 
     @Test
-    public void testGetTodayMission() throws Exception {
+    public void 오늘의_미션_조회_성공() throws Exception {
         // Given
         MissionGetTodayResponse missionGetTodayResponse =
                 new MissionGetTodayResponse(1L, "Test Mission");
@@ -70,7 +70,7 @@ public class MissionControllerTest {
     }
 
     @Test
-    public void testGetMission() throws Exception {
+    public void 미션_조회_성공() throws Exception {
         // Given
         MissionGetOneResponse missionGetOneResponse = new MissionGetOneResponse(1L, "Test Mission");
         when(missionService.getMission(1L)).thenReturn(missionGetOneResponse);
@@ -82,7 +82,7 @@ public class MissionControllerTest {
     }
 
     @Test
-    public void testUpdateMission() throws Exception {
+    public void 미션_수정_성공() throws Exception {
         // Given
         when(missionService.updateMission(anyLong(), any(MissionUpdateRequest.class)))
                 .thenReturn(new MissionUpdateResponse(1L, "Updated Mission"));
@@ -97,7 +97,7 @@ public class MissionControllerTest {
     }
 
     @Test
-    public void testDeleteMission() throws Exception {
+    public void 미션_삭제_성공() throws Exception {
         // Given
         doNothing().when(missionService).deleteMission(anyLong());
 

--- a/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
@@ -37,7 +37,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void testCreateMission() {
+    public void 미션_생성_성공() {
         // Given
         Mission mission = Mission.builder().title("Test Mission").build();
         when(missionRepository.save(any(Mission.class))).thenReturn(mission);
@@ -53,7 +53,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void testGetMission() {
+    public void 미션_단일_조회_성공() {
         // Given
         Mission mission = Mission.builder().title("Test Mission").build();
         when(missionRepository.findById(anyLong())).thenReturn(Optional.of(mission));
@@ -67,7 +67,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void testGetOrCreateTodayMission_오늘의_미션_히스토리가_이미_존재하는_경우() {
+    public void 오늘의_미션_조회_성공_히스토리가_이미_존재하는_경우() {
         // Given
         LocalDate today = LocalDate.now();
         Mission mission = Mission.builder().title("Test Mission").build();
@@ -88,7 +88,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    void testGetOrCreateTodayMission_오늘의_미션_히스토리가_없는_경우() {
+    public void 오늘의_미션_조회_성공_히스토리가_없는_경우() {
         // Given: 1 ~ 5일 전 데이터를 만든다
         LocalDate today = LocalDate.now();
         LocalDate threeDaysAgo = today.minusDays(3);
@@ -123,7 +123,8 @@ public class MissionServiceTest {
         }
 
         // 최근 3일간 할당되지 않은 미션 가져오는 동작을 모킹
-        when(missionRepository.findAllByIdNotIn(recentMissionIds)).thenReturn(missionsThreeDaysAgo);
+        when(missionRepository.findMissionsByIdNotIn(recentMissionIds))
+                .thenReturn(missionsThreeDaysAgo);
         when(missionHistoryRepository.save(any(MissionHistory.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -135,12 +136,12 @@ public class MissionServiceTest {
         assertThat(result.title()).isIn("4일 전 미션", "5일 전 미션");
         verify(missionHistoryRepository, times(1)).findByAssignedDate(today);
         verify(missionHistoryRepository, times(1)).findByAssignedDateBefore(threeDaysAgo);
-        verify(missionRepository, times(1)).findAllByIdNotIn(recentMissionIds);
+        verify(missionRepository, times(1)).findMissionsByIdNotIn(recentMissionIds);
         verify(missionHistoryRepository, times(1)).save(any(MissionHistory.class));
     }
 
     @Test
-    void testGetOrCreateTodayMission_할당가능한_미션이_없는_경우() {
+    public void 오늘의_미션_조회_실패_할당가능한_미션이_없는_경우() {
         LocalDate today = LocalDate.now();
         LocalDate threeDaysAgo = today.minusDays(3);
 
@@ -154,7 +155,7 @@ public class MissionServiceTest {
         List<Mission> emptyMissionList = new ArrayList<>();
 
         // 할당 가능한 미션이 없는 경우를 모킹
-        when(missionRepository.findAllByIdNotIn(emptyMissionIds)).thenReturn(emptyMissionList);
+        when(missionRepository.findMissionsByIdNotIn(emptyMissionIds)).thenReturn(emptyMissionList);
         when(missionHistoryRepository.save(any(MissionHistory.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -167,7 +168,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void testGetMissionNotFound() {
+    public void 미션_조회_미션이_없는_경우() {
         // Given
 
         // When
@@ -179,7 +180,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void testUpdateMission() {
+    public void 미션_수정_성공() {
         // Given
         Mission mission = Mission.builder().title("Test Mission").build();
         when(missionRepository.findById(anyLong())).thenReturn(Optional.of(mission));
@@ -195,7 +196,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void testUpdateMissionNotFound() {
+    public void 미션_수정_실패_미션이_없는_경우() {
         // Given
         when(missionRepository.findById(anyLong())).thenReturn(Optional.empty());
         MissionUpdateRequest updateRequest = new MissionUpdateRequest("Test Mission");
@@ -205,7 +206,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void testDeleteMission() {
+    public void 미션_삭제_성공() {
         // Given
         doNothing().when(missionRepository).deleteById(anyLong());
 

--- a/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
@@ -4,15 +4,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
+import com.depromeet.stonebed.domain.mission.dao.MissionHistoryRepository;
 import com.depromeet.stonebed.domain.mission.dao.MissionRepository;
 import com.depromeet.stonebed.domain.mission.domain.Mission;
+import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
 import com.depromeet.stonebed.domain.mission.dto.request.MissionCreateRequest;
 import com.depromeet.stonebed.domain.mission.dto.request.MissionUpdateRequest;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionCreateResponse;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionGetOneResponse;
+import com.depromeet.stonebed.domain.mission.dto.response.MissionGetTodayResponse;
 import com.depromeet.stonebed.domain.mission.dto.response.MissionUpdateResponse;
+import com.depromeet.stonebed.global.error.ErrorCode;
 import com.depromeet.stonebed.global.error.exception.CustomException;
-import java.util.Optional;
+import java.time.LocalDate;
+import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -22,6 +27,7 @@ import org.mockito.MockitoAnnotations;
 public class MissionServiceTest {
 
     @Mock private MissionRepository missionRepository;
+    @Mock private MissionHistoryRepository missionHistoryRepository;
 
     @InjectMocks private MissionService missionService;
 
@@ -58,6 +64,106 @@ public class MissionServiceTest {
         // Then
         assertThat(missionGetOneResponse.title()).isEqualTo("Test Mission");
         verify(missionRepository, times(1)).findById(anyLong());
+    }
+
+    @Test
+    public void testGetOrCreateTodayMission_오늘의_미션_히스토리가_이미_존재하는_경우() {
+        // Given
+        LocalDate today = LocalDate.now();
+        Mission mission = Mission.builder().title("Test Mission").build();
+        MissionHistory missionHistory =
+                MissionHistory.builder().mission(mission).assignedDate(today).build();
+
+        when(missionHistoryRepository.findByAssignedDate(today))
+                .thenReturn(Optional.of(missionHistory));
+
+        // When
+        MissionGetTodayResponse result = missionService.getOrCreateTodayMission();
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isEqualTo("Test Mission");
+        verify(missionHistoryRepository, times(1)).findByAssignedDate(today);
+        verify(missionHistoryRepository, times(0)).save(any(MissionHistory.class));
+    }
+
+    @Test
+    void testGetOrCreateTodayMission_오늘의_미션_히스토리가_없는_경우() {
+        // Given: 1 ~ 5일 전 데이터를 만든다
+        LocalDate today = LocalDate.now();
+        LocalDate threeDaysAgo = today.minusDays(3);
+
+        List<MissionHistory> recentMissionHistories = new ArrayList<>();
+        List<Long> recentMissionIds = new ArrayList<>();
+
+        // 1일 전 ~ 3일 전
+        for (int i = 1; i < 4; i++) {
+            LocalDate date = today.minusDays(i);
+            Mission mission = spy(Mission.builder().title(String.format("%d일 전 미션", i)).build());
+            MissionHistory missionHistory =
+                    MissionHistory.builder().mission(mission).assignedDate(date).build();
+
+            recentMissionHistories.add(missionHistory);
+            recentMissionIds.add((long) i);
+            doReturn((long) i).when(mission).getId();
+        }
+
+        // 오늘의 히스토리가 없다는 동작을 모킹
+        when(missionHistoryRepository.findByAssignedDate(today)).thenReturn(Optional.empty());
+        // 3일이내 미션 히스토리를 가져왔을 때 위에 1일전, 2일전, 3일전 미션히스토리를 가져옴
+        when(missionHistoryRepository.findByAssignedDateBefore(threeDaysAgo))
+                .thenReturn(recentMissionHistories);
+
+        List<Mission> missionsThreeDaysAgo = new ArrayList<>();
+
+        // 4일 전 ~ 5일 전
+        for (int i = 4; i < 6; i++) {
+            Mission mission = spy(Mission.builder().title(String.format("%d일 전 미션", i)).build());
+            missionsThreeDaysAgo.add(mission);
+        }
+
+        // 최근 3일간 할당되지 않은 미션 가져오는 동작을 모킹
+        when(missionRepository.findAllByIdNotIn(recentMissionIds)).thenReturn(missionsThreeDaysAgo);
+        when(missionHistoryRepository.save(any(MissionHistory.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When: getOrCreateTodayMission 을 호출하면
+        MissionGetTodayResponse result = missionService.getOrCreateTodayMission();
+
+        // Then: 각 메서드들이 실행됐는지 검증
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isIn("4일 전 미션", "5일 전 미션");
+        verify(missionHistoryRepository, times(1)).findByAssignedDate(today);
+        verify(missionHistoryRepository, times(1)).findByAssignedDateBefore(threeDaysAgo);
+        verify(missionRepository, times(1)).findAllByIdNotIn(recentMissionIds);
+        verify(missionHistoryRepository, times(1)).save(any(MissionHistory.class));
+    }
+
+    @Test
+    void testGetOrCreateTodayMission_할당가능한_미션이_없는_경우() {
+        LocalDate today = LocalDate.now();
+        LocalDate threeDaysAgo = today.minusDays(3);
+
+        List<MissionHistory> emptyMissionHistories = new ArrayList<>();
+        List<Long> emptyMissionIds = new ArrayList<>();
+
+        when(missionHistoryRepository.findByAssignedDate(today)).thenReturn(Optional.empty());
+        when(missionHistoryRepository.findByAssignedDateBefore(threeDaysAgo))
+                .thenReturn(emptyMissionHistories);
+
+        List<Mission> emptyMissionList = new ArrayList<>();
+
+        // 할당 가능한 미션이 없는 경우를 모킹
+        when(missionRepository.findAllByIdNotIn(emptyMissionIds)).thenReturn(emptyMissionList);
+        when(missionHistoryRepository.save(any(MissionHistory.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When: getOrCreateTodayMission 을 호출하면
+        CustomException exception =
+                assertThrows(CustomException.class, () -> missionService.getOrCreateTodayMission());
+
+        // Then: 에러코드 검증
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NO_AVAILABLE_TODAY_MISSION);
     }
 
     @Test

--- a/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
@@ -1,0 +1,89 @@
+package com.depromeet.stonebed.domain.mission.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.depromeet.stonebed.domain.mission.domain.Mission;
+import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+public class MissionHistoryRepositoryTest {
+
+    @Autowired private MissionRepository missionRepository;
+    @Autowired private MissionHistoryRepository missionHistoryRepository;
+
+    @Test
+    public void testCreateMissionHistory() {
+        // Given: 오늘 날짜를 기준으로 미션 히스토리가 있다 (생성할 예정)
+        Mission mission = Mission.builder().title("Test Mission").build();
+        missionRepository.save(mission);
+        LocalDate today = LocalDate.now();
+
+        MissionHistory missionHistory =
+                MissionHistory.builder().mission(mission).assignedDate(today).build();
+
+        // When: 미션 히스토리를 저장하면
+        MissionHistory savedMissionHistory = missionHistoryRepository.save(missionHistory);
+
+        // Then: 저장된 미션 히스토리가 올바른지 검증한다
+        assertThat(savedMissionHistory.getId()).isNotNull();
+        assertThat(savedMissionHistory.getMission().getTitle()).isEqualTo("Test Mission");
+        assertThat(savedMissionHistory.getAssignedDate()).isEqualTo(today);
+    }
+
+    @Test
+    public void testFindMissionHistoryByAssignedDate() {
+        // Given: 오늘 날짜를 기준으로 저장된 객체가 있다
+        Mission mission = Mission.builder().title("Test Mission").build();
+        missionRepository.save(mission);
+        LocalDate today = LocalDate.now();
+
+        MissionHistory missionHistory =
+                MissionHistory.builder().mission(mission).assignedDate(today).build();
+        missionHistoryRepository.save(missionHistory);
+
+        // When: 특정 날짜(오늘)의 미션 히스토리를 가져오면
+        Optional<MissionHistory> foundMissionHistory =
+                missionHistoryRepository.findByAssignedDate(today);
+
+        // Then: 가져온 미션 히스토리가 올바른지 검증한다
+        assertThat(foundMissionHistory).isPresent();
+        assertThat(foundMissionHistory.get().getMission().getTitle()).isEqualTo("Test Mission");
+        assertThat(foundMissionHistory.get().getAssignedDate()).isEqualTo(today);
+    }
+
+    @Test
+    public void testFindMissionHistoriesBeforeFiveDaysAgo() {
+        // Given: 최근 10일간 미션과 미션 히스토리를 미리 만들어둔다
+        Mission mission = Mission.builder().title("Test Mission").build();
+        missionRepository.save(mission);
+
+        LocalDate today = LocalDate.now();
+        for (int i = 1; i < 11; i++) {
+            LocalDate date = today.minusDays(i);
+            MissionHistory missionHistory =
+                    MissionHistory.builder().mission(mission).assignedDate(date).build();
+            missionHistoryRepository.save(missionHistory);
+        }
+
+        LocalDate fiveDaysAgo = today.minusDays(5);
+
+        // When: 5일 전 히스토리 기록을 가져오면
+        List<MissionHistory> missionHistories =
+                missionHistoryRepository.findByAssignedDateBefore(fiveDaysAgo);
+
+        // Then: 실제로 5일 전의 데이터가 가져와졌는지 확인한다
+        assertThat(missionHistories).isNotEmpty();
+        assertThat(missionHistories.size()).isEqualTo(5);
+        assertThat(missionHistories)
+                .allMatch(history -> history.getAssignedDate().isBefore(fiveDaysAgo));
+    }
+}

--- a/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
@@ -2,19 +2,21 @@ package com.depromeet.stonebed.domain.mission.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.depromeet.stonebed.TestQuerydslConfig;
 import com.depromeet.stonebed.domain.mission.domain.Mission;
 import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
+@Import(TestQuerydslConfig.class)
 public class MissionHistoryRepositoryTest {
 
     @Autowired private MissionRepository missionRepository;
@@ -58,32 +60,5 @@ public class MissionHistoryRepositoryTest {
         assertThat(foundMissionHistory).isPresent();
         assertThat(foundMissionHistory.get().getMission().getTitle()).isEqualTo("Test Mission");
         assertThat(foundMissionHistory.get().getAssignedDate()).isEqualTo(today);
-    }
-
-    @Test
-    public void 미션_히스토리_리스트_5일전_조회_성공() {
-        // Given: 최근 10일간 미션과 미션 히스토리를 미리 만들어둔다
-        Mission mission = Mission.builder().title("Test Mission").build();
-        missionRepository.save(mission);
-
-        LocalDate today = LocalDate.now();
-        for (int i = 1; i < 11; i++) {
-            LocalDate date = today.minusDays(i);
-            MissionHistory missionHistory =
-                    MissionHistory.builder().mission(mission).assignedDate(date).build();
-            missionHistoryRepository.save(missionHistory);
-        }
-
-        LocalDate fiveDaysAgo = today.minusDays(5);
-
-        // When: 5일 전 히스토리 기록을 가져오면
-        List<MissionHistory> missionHistories =
-                missionHistoryRepository.findByAssignedDateBefore(fiveDaysAgo);
-
-        // Then: 실제로 5일 전의 데이터가 가져와졌는지 확인한다
-        assertThat(missionHistories).isNotEmpty();
-        assertThat(missionHistories.size()).isEqualTo(5);
-        assertThat(missionHistories)
-                .allMatch(history -> history.getAssignedDate().isBefore(fiveDaysAgo));
     }
 }

--- a/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
@@ -21,7 +21,7 @@ public class MissionHistoryRepositoryTest {
     @Autowired private MissionHistoryRepository missionHistoryRepository;
 
     @Test
-    public void testCreateMissionHistory() {
+    public void 미션_히스토리_생성_성공() {
         // Given: 오늘 날짜를 기준으로 미션 히스토리가 있다 (생성할 예정)
         Mission mission = Mission.builder().title("Test Mission").build();
         missionRepository.save(mission);
@@ -40,7 +40,7 @@ public class MissionHistoryRepositoryTest {
     }
 
     @Test
-    public void testFindMissionHistoryByAssignedDate() {
+    public void 미션_히스토리_특정_날짜_조회_성공() {
         // Given: 오늘 날짜를 기준으로 저장된 객체가 있다
         Mission mission = Mission.builder().title("Test Mission").build();
         missionRepository.save(mission);
@@ -61,7 +61,7 @@ public class MissionHistoryRepositoryTest {
     }
 
     @Test
-    public void testFindMissionHistoriesBeforeFiveDaysAgo() {
+    public void 미션_히스토리_리스트_5일전_조회_성공() {
         // Given: 최근 10일간 미션과 미션 히스토리를 미리 만들어둔다
         Mission mission = Mission.builder().title("Test Mission").build();
         missionRepository.save(mission);

--- a/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionRepositoryTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionRepositoryTest.java
@@ -16,7 +16,7 @@ public class MissionRepositoryTest {
     @Autowired private MissionRepository missionRepository;
 
     @Test
-    public void testCreateMission() {
+    public void 미션_생성_성공() {
         // Given
         Mission mission = Mission.builder().title("Test Mission").build();
 
@@ -29,7 +29,7 @@ public class MissionRepositoryTest {
     }
 
     @Test
-    public void testFindMissionById() {
+    public void 고유번호로_미션_조회_성공() {
         // Given
         Mission mission = Mission.builder().title("Test Mission").build();
         missionRepository.save(mission);
@@ -43,7 +43,7 @@ public class MissionRepositoryTest {
     }
 
     @Test
-    public void testDeleteMission() {
+    public void 미션_삭제_성공() {
         // Given
         Mission mission = Mission.builder().title("Test Mission").build();
         mission = missionRepository.save(mission);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #51 

## 📌 작업 내용
- GET /missions/today 엔드포인트 추가
- 3일 내에 할당된 미션은 다시 할당되지 않음

## 🙏 리뷰 요구사항
- 로직을 테스트에 적용했더니 꽤 복잡해서 주석을 많이 사용했어요
- 전에 말씀해주셨던 publishedAt 보다 date같아서 At 말고 Date 를 사용했고, publish는 뭔가 발행일 같아서 할당된 날짜...? 같은 느낌으로 assignedDate로 지어봤어요
- 테스트에 fixture monkey는 ... 사진 업로드까지만 하고 지금까지 작업한거 리팩토링 해보겠습니당...

## 📚 레퍼런스
- Secure Random 보안 경고 ([Link](https://github.com/depromeet/WalWal-server/pull/53#issue-2422751877))
  - [자바의 난수생성기 Random, SecureRandom](https://velog.io/@dudwls0505/%EC%9E%90%EB%B0%94%EC%9D%98-%EB%82%9C%EC%88%98%EC%83%9D%EC%84%B1%EA%B8%B0-Random-SecureRandom)
  - [[Java] Random보단 SecureRandom 를 사용하자.](https://kdhyo98.tistory.com/48#google_vignette)
