### PR TITLE
[WALWAL-160] 미션 시작 시 동시성 문제 개선

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepository.java
@@ -6,7 +6,8 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MissionHistoryRepository extends JpaRepository<MissionHistory, Long> {
+public interface MissionHistoryRepository
+        extends JpaRepository<MissionHistory, Long>, MissionHistoryRepositoryCustom {
     Optional<MissionHistory> findByAssignedDate(LocalDate date);
 
     List<MissionHistory> findByAssignedDateBefore(LocalDate date);

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryCustom.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.depromeet.stonebed.domain.mission.dao;
+
+import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
+import java.util.Optional;
+
+public interface MissionHistoryRepositoryCustom {
+    Optional<MissionHistory> findLatestOneByMissionId(Long missionId);
+}

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryImpl.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.depromeet.stonebed.domain.mission.dao;
+
+import static com.depromeet.stonebed.domain.mission.domain.QMissionHistory.missionHistory;
+
+import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MissionHistoryRepositoryImpl implements MissionHistoryRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<MissionHistory> findLatestOneByMissionId(Long missionId) {
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(missionHistory)
+                        .where(missionHistory.mission.id.eq(missionId))
+                        .orderBy(missionHistory.assignedDate.desc())
+                        .fetchFirst());
+    }
+}

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepository.java
@@ -1,7 +1,7 @@
 package com.depromeet.stonebed.domain.missionRecord.dao;
 
 import com.depromeet.stonebed.domain.member.domain.Member;
-import com.depromeet.stonebed.domain.mission.domain.Mission;
+import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordStatus;
 import java.util.Optional;
@@ -9,7 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissionRecordRepository
         extends JpaRepository<MissionRecord, Long>, MissionRecordRepositoryCustom {
-    Optional<MissionRecord> findByMemberAndMission(Member member, Mission mission);
+    Optional<MissionRecord> findByMemberAndMissionHistory(
+            Member member, MissionHistory missionHistory);
 
     Long countByMemberIdAndStatus(Long memberId, MissionRecordStatus status);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecord.java
@@ -2,17 +2,9 @@ package com.depromeet.stonebed.domain.missionRecord.domain;
 
 import com.depromeet.stonebed.domain.common.BaseTimeEntity;
 import com.depromeet.stonebed.domain.member.domain.Member;
-import com.depromeet.stonebed.domain.mission.domain.Mission;
+import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,6 +13,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "mission_record",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_member_mission_history",
+                    columnNames = {"member_id", "mission_history_id"})
+        })
 public class MissionRecord extends BaseTimeEntity {
 
     @Id
@@ -29,8 +28,8 @@ public class MissionRecord extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "mission_id", nullable = false)
-    private Mission mission;
+    @JoinColumn(name = "mission_history_id", nullable = false)
+    private MissionHistory missionHistory;
 
     @ManyToOne
     @JoinColumn(name = "member_id", nullable = false)
@@ -46,9 +45,12 @@ public class MissionRecord extends BaseTimeEntity {
 
     @Builder
     public MissionRecord(
-            Member member, Mission mission, String imageUrl, MissionRecordStatus status) {
+            Member member,
+            MissionHistory missionHistory,
+            String imageUrl,
+            MissionRecordStatus status) {
         this.member = member;
-        this.mission = mission;
+        this.missionHistory = missionHistory;
         this.imageUrl = imageUrl;
         this.status = status;
     }

--- a/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
+++ b/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
 
     // mission
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션을 찾을 수 없습니다."),
+    MISSION_HISTORY_NOT_FOUNT(HttpStatus.NOT_FOUND, "해당 일별 미션 정보를 찾을 수 없습니다."),
     MISSION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션 기록을 찾을 수 없습니다."),
     NO_AVAILABLE_TODAY_MISSION(HttpStatus.INTERNAL_SERVER_ERROR, "할당 가능한 오늘의 미션이 없습니다."),
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #72 

## 📌 작업 내용
- 기존 mission:missionRecord 1:N 관계에서 missionHistory:missionRecord 1:N 관계로 변경
- 문제는 missionRecord의 중복 생성인데, assignedDate, member_id, mission 이렇게 3개가 고유 제약 조건이어야 한다
- 하지만 mission은 날짜를 구분하는 assignedDate가 없기 때문에 missionHistroy로 관계를 변경
- 그리고 기존 missionRecord 관련 서비스에서 mission 으로 찾고, mission을 넣어주는 과정을 전부 missionHistory로 변경

## 🙏 리뷰 요구사항
- unique key 네이밍이나 querydsl 네이밍에서 더 좋은 이름이 있다면 추천을 해주세용

## 📚 레퍼런스
- 
