### PR TITLE
[WALWAL-163] 배포 환경 메모리 제한

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,10 @@ services:
     network_mode: host
     env_file:
       - ~/.env
+    deploy:
+      resources:
+        limits:
+          memory: 512m
   redis:
     image: "redis:alpine"
     container_name: redis
@@ -18,6 +22,10 @@ services:
     environment:
       - TZ=Asia/Seoul
     network_mode: "host"
+    deploy:
+      resources:
+        limits:
+          memory: 128m
   nginx:
     image: "nginx:alpine"
     container_name: nginx
@@ -26,3 +34,7 @@ services:
     network_mode: host
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+    deploy:
+      resources:
+        limits:
+          memory: 128m

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512m
+          memory: 640m
   redis:
     image: "redis:alpine"
     container_name: redis


### PR DESCRIPTION
## 🌱 관련 이슈
- close #76 

## 📌 작업 내용
- 도커 컴포즈 메모리 제한
- 배포 환경 t3.micro 메모리 1기가에서 원활하게 애플리케이션이 동작하도록 메모리를 제한합니다
- Springboot: 640 (512 + 128) MB
- Redis: 128 MB
- Nginx: 128 MB

## 🙏 리뷰 요구사항
- 인스턴스에서 128 정도는 여유있게 할당해봤어요

## 📚 레퍼런스
- 
