### PR TITLE
refactor: fixtureMonkey setUp 함수 추상 클래스로 상속으로 개선

### DIFF
--- a/src/test/java/com/depromeet/stonebed/FixtureMonkeySetUp.java
+++ b/src/test/java/com/depromeet/stonebed/FixtureMonkeySetUp.java
@@ -1,0 +1,22 @@
+package com.depromeet.stonebed;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class FixtureMonkeySetUp {
+
+    protected FixtureMonkey fixtureMonkey;
+
+    @BeforeEach
+    void setUpFixtureMonkey() {
+        fixtureMonkey =
+                FixtureMonkey.builder()
+                        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+                        .defaultNotNull(true)
+                        .build();
+    }
+}

--- a/src/test/java/com/depromeet/stonebed/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/auth/application/AuthServiceTest.java
@@ -3,14 +3,13 @@ package com.depromeet.stonebed.domain.auth.application;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.auth.domain.OAuthProvider;
 import com.depromeet.stonebed.domain.auth.dto.response.AuthTokenResponse;
 import com.depromeet.stonebed.domain.auth.dto.response.TokenPairResponse;
 import com.depromeet.stonebed.domain.member.dao.MemberRepository;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.domain.member.domain.MemberRole;
-import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,7 +21,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
-class AuthServiceTest {
+class AuthServiceTest extends FixtureMonkeySetUp {
 
     @InjectMocks private AuthService authService;
 
@@ -36,12 +35,6 @@ class AuthServiceTest {
 
     @BeforeEach
     void setUp() {
-        FixtureMonkey fixtureMonkey =
-                FixtureMonkey.builder()
-                        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
-                        .defaultNotNull(true)
-                        .build();
-
         oauthId = fixtureMonkey.giveMeOne(String.class);
         email = fixtureMonkey.giveMeOne(String.class);
         member = fixtureMonkey.giveMeOne(Member.class);

--- a/src/test/java/com/depromeet/stonebed/domain/auth/application/JwtTokenServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/auth/application/JwtTokenServiceTest.java
@@ -4,6 +4,7 @@ import static com.depromeet.stonebed.global.common.constants.SecurityConstants.*
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.auth.dao.RefreshTokenRepository;
 import com.depromeet.stonebed.domain.auth.domain.RefreshToken;
 import com.depromeet.stonebed.domain.auth.dto.AccessTokenDto;
@@ -12,11 +13,8 @@ import com.depromeet.stonebed.domain.auth.dto.response.TokenPairResponse;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.domain.member.domain.MemberRole;
 import com.depromeet.stonebed.global.util.JwtUtil;
-import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import io.jsonwebtoken.ExpiredJwtException;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,23 +24,12 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
-class JwtTokenServiceTest {
+class JwtTokenServiceTest extends FixtureMonkeySetUp {
 
     @InjectMocks private JwtTokenService jwtTokenService;
 
     @Mock private JwtUtil jwtUtil;
     @Mock private RefreshTokenRepository refreshTokenRepository;
-
-    private FixtureMonkey fixtureMonkey;
-
-    @BeforeEach
-    void setUp() {
-        fixtureMonkey =
-                FixtureMonkey.builder()
-                        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
-                        .defaultNotNull(true)
-                        .build();
-    }
 
     @Test
     void 토큰_PAIR를_생성합니다() {

--- a/src/test/java/com/depromeet/stonebed/domain/feed/application/FeedServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/feed/application/FeedServiceTest.java
@@ -1,42 +1,32 @@
 package com.depromeet.stonebed.domain.feed.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.feed.dao.FeedRepository;
 import com.depromeet.stonebed.domain.feed.dto.request.FeedGetRequest;
 import com.depromeet.stonebed.domain.feed.dto.response.FeedGetResponse;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.stonebed.global.util.MemberUtil;
-import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
 
-public class FeedServiceTest {
-    @Mock private FeedRepository feedRepository;
-
-    @Mock private MemberUtil memberUtil;
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class FeedServiceTest extends FixtureMonkeySetUp {
 
     @InjectMocks private FeedService feedService;
 
-    private FixtureMonkey fixtureMonkey;
-
-    @BeforeEach
-    void setUp() {
-        fixtureMonkey =
-                FixtureMonkey.builder()
-                        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
-                        .defaultNotNull(true)
-                        .build();
-        MockitoAnnotations.openMocks(this);
-    }
+    @Mock private FeedRepository feedRepository;
+    @Mock private MemberUtil memberUtil;
 
     @Test
     void 피드_조회_성공() {

--- a/src/test/java/com/depromeet/stonebed/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/follow/application/FollowServiceTest.java
@@ -3,6 +3,7 @@ package com.depromeet.stonebed.domain.follow.application;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.follow.dao.FollowRepository;
 import com.depromeet.stonebed.domain.follow.domain.Follow;
 import com.depromeet.stonebed.domain.follow.dto.request.FollowCreateRequest;
@@ -14,39 +15,23 @@ import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.global.error.ErrorCode;
 import com.depromeet.stonebed.global.error.exception.CustomException;
 import com.depromeet.stonebed.global.util.MemberUtil;
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
 @ActiveProfiles("test")
-class FollowServiceTest {
+@ExtendWith(MockitoExtension.class)
+class FollowServiceTest extends FixtureMonkeySetUp {
 
     @InjectMocks private FollowService followService;
-    @MockBean private FirebaseMessaging firebaseMessaging;
 
     @Mock private MemberUtil memberUtil;
     @Mock private FollowRepository followRepository;
     @Mock private MemberRepository memberRepository;
-
-    private FixtureMonkey fixtureMonkey;
-
-    @BeforeEach
-    void setUp() {
-        fixtureMonkey =
-                FixtureMonkey.builder()
-                        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
-                        .defaultNotNull(true)
-                        .build();
-    }
 
     @Test
     void 팔로우를_진행합니다() {

--- a/src/test/java/com/depromeet/stonebed/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/member/application/MemberServiceTest.java
@@ -3,12 +3,10 @@ package com.depromeet.stonebed.domain.member.application;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.domain.member.dto.request.NicknameCheckRequest;
 import com.depromeet.stonebed.global.util.MemberUtil;
-import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,22 +16,11 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
-class MemberServiceTest {
+class MemberServiceTest extends FixtureMonkeySetUp {
 
     @InjectMocks private MemberService memberService;
 
     @Mock private MemberUtil memberUtil;
-
-    private FixtureMonkey fixtureMonkey;
-
-    @BeforeEach
-    void setUp() {
-        fixtureMonkey =
-                FixtureMonkey.builder()
-                        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
-                        .defaultNotNull(true)
-                        .build();
-    }
 
     @Test
     void 사용자_정보를_조회한다() {

--- a/src/test/java/com/depromeet/stonebed/domain/member/domain/MemberTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/member/domain/MemberTest.java
@@ -2,29 +2,16 @@ package com.depromeet.stonebed.domain.member.domain;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.auth.domain.OAuthProvider;
 import com.depromeet.stonebed.global.error.ErrorCode;
 import com.depromeet.stonebed.global.error.exception.CustomException;
-import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import java.time.LocalDateTime;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
-class MemberTest {
-
-    private FixtureMonkey fixtureMonkey;
-
-    @BeforeEach
-    void setUp() {
-        fixtureMonkey =
-                FixtureMonkey.builder()
-                        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
-                        .defaultNotNull(true)
-                        .build();
-    }
+class MemberTest extends FixtureMonkeySetUp {
 
     @Test
     void createMember_성공() {

--- a/src/test/java/com/depromeet/stonebed/domain/mission/api/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/api/MissionControllerTest.java
@@ -18,10 +18,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-public class MissionControllerTest {
+@ActiveProfiles("test")
+class MissionControllerTest {
 
     private MockMvc mockMvc;
 
@@ -41,7 +43,7 @@ public class MissionControllerTest {
     }
 
     @Test
-    public void 미션_생성_성공() throws Exception {
+    void 미션_생성_성공() throws Exception {
         // Given
         MissionCreateResponse missionCreateResponse = new MissionCreateResponse(1L, "Test Mission");
         when(missionService.createMission(any(MissionCreateRequest.class)))
@@ -57,7 +59,7 @@ public class MissionControllerTest {
     }
 
     @Test
-    public void 오늘의_미션_조회_성공() throws Exception {
+    void 오늘의_미션_조회_성공() throws Exception {
         // Given
         MissionGetTodayResponse missionGetTodayResponse =
                 new MissionGetTodayResponse(1L, "Test Mission", "https://example.com/image.png");
@@ -70,7 +72,7 @@ public class MissionControllerTest {
     }
 
     @Test
-    public void 미션_조회_성공() throws Exception {
+    void 미션_조회_성공() throws Exception {
         // Given
         MissionGetOneResponse missionGetOneResponse = new MissionGetOneResponse(1L, "Test Mission");
         when(missionService.getMission(1L)).thenReturn(missionGetOneResponse);
@@ -82,7 +84,7 @@ public class MissionControllerTest {
     }
 
     @Test
-    public void 미션_수정_성공() throws Exception {
+    void 미션_수정_성공() throws Exception {
         // Given
         when(missionService.updateMission(anyLong(), any(MissionUpdateRequest.class)))
                 .thenReturn(new MissionUpdateResponse(1L, "Updated Mission"));
@@ -97,7 +99,7 @@ public class MissionControllerTest {
     }
 
     @Test
-    public void 미션_삭제_성공() throws Exception {
+    void 미션_삭제_성공() throws Exception {
         // Given
         doNothing().when(missionService).deleteMission(anyLong());
 

--- a/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
@@ -23,8 +23,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.ActiveProfiles;
 
-public class MissionServiceTest {
+@ActiveProfiles("test")
+class MissionServiceTest {
 
     @Mock private MissionRepository missionRepository;
     @Mock private MissionHistoryRepository missionHistoryRepository;
@@ -46,7 +48,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void 미션_생성_성공() {
+    void 미션_생성_성공() {
         // Given
         when(missionRepository.save(any(Mission.class))).thenReturn(mission);
         MissionCreateRequest missionCreateRequest = new MissionCreateRequest("Test Mission");
@@ -61,7 +63,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void 미션_단일_조회_성공() {
+    void 미션_단일_조회_성공() {
         // Given
         when(missionRepository.findById(anyLong())).thenReturn(Optional.of(mission));
 
@@ -74,7 +76,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void 오늘의_미션_조회_성공_히스토리가_이미_존재하는_경우() {
+    void 오늘의_미션_조회_성공_히스토리가_이미_존재하는_경우() {
         // Given
         when(missionHistoryRepository.findByAssignedDate(today))
                 .thenReturn(Optional.of(missionHistory));
@@ -90,7 +92,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void 오늘의_미션_조회_성공_히스토리가_없는_경우() {
+    void 오늘의_미션_조회_성공_히스토리가_없는_경우() {
         // Given: 초기 설정
         List<Mission> recentMissions = new ArrayList<>();
         recentMissions.add(Mission.builder().title("1일 전 미션").build());
@@ -117,7 +119,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void 오늘의_미션_조회_실패_할당가능한_미션이_없는_경우() {
+    void 오늘의_미션_조회_실패_할당가능한_미션이_없는_경우() {
         // Given: 초기 설정
         List<Mission> emptyMissionList = new ArrayList<>();
 
@@ -137,7 +139,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void 미션_조회_미션이_없는_경우() {
+    void 미션_조회_미션이_없는_경우() {
         // Given
 
         // When
@@ -149,7 +151,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void 미션_수정_성공() {
+    void 미션_수정_성공() {
         // Given
         when(missionRepository.findById(anyLong())).thenReturn(Optional.of(mission));
 
@@ -164,7 +166,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void 미션_수정_실패_미션이_없는_경우() {
+    void 미션_수정_실패_미션이_없는_경우() {
         // Given
         when(missionRepository.findById(anyLong())).thenReturn(Optional.empty());
         MissionUpdateRequest updateRequest = new MissionUpdateRequest("Test Mission");
@@ -174,7 +176,7 @@ public class MissionServiceTest {
     }
 
     @Test
-    public void 미션_삭제_성공() {
+    void 미션_삭제_성공() {
         // Given
         doNothing().when(missionRepository).deleteById(anyLong());
 

--- a/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
@@ -14,18 +14,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
 @Import(TestQuerydslConfig.class)
-public class MissionHistoryRepositoryTest {
+class MissionHistoryRepositoryTest {
 
     @Autowired private MissionRepository missionRepository;
     @Autowired private MissionHistoryRepository missionHistoryRepository;
 
     @Test
-    public void 미션_히스토리_생성_성공() {
+    void 미션_히스토리_생성_성공() {
         // Given: 오늘 날짜를 기준으로 미션 히스토리가 있다 (생성할 예정)
         Mission mission = Mission.builder().title("Test Mission").build();
         missionRepository.save(mission);
@@ -44,7 +46,7 @@ public class MissionHistoryRepositoryTest {
     }
 
     @Test
-    public void 미션_히스토리_특정_날짜_조회_성공() {
+    void 미션_히스토리_특정_날짜_조회_성공() {
         // Given: 오늘 날짜를 기준으로 저장된 객체가 있다
         Mission mission = Mission.builder().title("Test Mission").build();
         missionRepository.save(mission);

--- a/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionRepositoryTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionRepositoryTest.java
@@ -9,15 +9,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
+@ActiveProfiles("test")
 @Import(TestQuerydslConfig.class)
-public class MissionRepositoryTest {
+class MissionRepositoryTest {
 
     @Autowired private MissionRepository missionRepository;
 
     @Test
-    public void 미션_생성_성공() {
+    void 미션_생성_성공() {
         // Given
         Mission mission = Mission.builder().title("Test Mission").build();
 
@@ -30,7 +32,7 @@ public class MissionRepositoryTest {
     }
 
     @Test
-    public void 고유번호로_미션_조회_성공() {
+    void 고유번호로_미션_조회_성공() {
         // Given
         Mission mission = Mission.builder().title("Test Mission").build();
         missionRepository.save(mission);
@@ -44,7 +46,7 @@ public class MissionRepositoryTest {
     }
 
     @Test
-    public void 미션_삭제_성공() {
+    void 미션_삭제_성공() {
         // Given
         Mission mission = Mission.builder().title("Test Mission").build();
         mission = missionRepository.save(mission);

--- a/src/test/java/com/depromeet/stonebed/domain/missionRecord/MissionRecordServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/missionRecord/MissionRecordServiceTest.java
@@ -3,6 +3,7 @@ package com.depromeet.stonebed.domain.missionRecord;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.Mockito.*;
 
+import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.domain.mission.dao.missionHistory.MissionHistoryRepository;
 import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
@@ -15,11 +16,8 @@ import com.depromeet.stonebed.domain.missionRecord.dto.response.MissionRecordCal
 import com.depromeet.stonebed.global.error.ErrorCode;
 import com.depromeet.stonebed.global.error.exception.CustomException;
 import com.depromeet.stonebed.global.util.MemberUtil;
-import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,26 +26,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
-public class MissionRecordServiceTest {
+class MissionRecordServiceTest extends FixtureMonkeySetUp {
 
     @InjectMocks private MissionRecordService missionRecordService;
 
     @Mock private MissionRecordRepository missionRecordRepository;
     @Mock private MissionHistoryRepository missionHistoryRepository;
     @Mock private MemberUtil memberUtil;
-
-    private FixtureMonkey fixtureMonkey;
-
-    @BeforeEach
-    void setUp() {
-        fixtureMonkey =
-                FixtureMonkey.builder()
-                        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
-                        .defaultNotNull(true)
-                        .build();
-    }
 
     @Test
     void 미션기록_성공() {

--- a/src/test/java/com/depromeet/stonebed/global/util/MemberUtilTest.java
+++ b/src/test/java/com/depromeet/stonebed/global/util/MemberUtilTest.java
@@ -3,15 +3,13 @@ package com.depromeet.stonebed.global.util;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.member.dao.MemberRepository;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.domain.member.dto.request.NicknameCheckRequest;
 import com.depromeet.stonebed.global.error.ErrorCode;
 import com.depromeet.stonebed.global.error.exception.CustomException;
-import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -21,24 +19,13 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
-class MemberUtilTest {
+class MemberUtilTest extends FixtureMonkeySetUp {
 
     @InjectMocks private MemberUtil memberUtil;
 
     @Mock private SecurityUtil securityUtil;
 
     @Mock private MemberRepository memberRepository;
-
-    private FixtureMonkey fixtureMonkey;
-
-    @BeforeEach
-    void setUp() {
-        fixtureMonkey =
-                FixtureMonkey.builder()
-                        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
-                        .defaultNotNull(true)
-                        .build();
-    }
 
     @Test
     void getCurrentMember_성공() {

--- a/src/test/java/com/depromeet/stonebed/global/util/SecurityUtilTest.java
+++ b/src/test/java/com/depromeet/stonebed/global/util/SecurityUtilTest.java
@@ -14,7 +14,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class SecurityUtilTest {
 

--- a/src/test/java/com/depromeet/stonebed/global/util/SpringEnvironmentUtilTest.java
+++ b/src/test/java/com/depromeet/stonebed/global/util/SpringEnvironmentUtilTest.java
@@ -10,7 +10,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class SpringEnvironmentUtilTest {
     private static final String[] PROD_ARRAY = new String[] {PROD_ENV};


### PR DESCRIPTION
## 🌱 관련 이슈
- close #105 

## 📌 작업 내용
- 공통으로 사용된 setUp 함수 내부 중 fixtureMonkey 사용이 중복적으로 사용되는 것을 추상 클래스를 사용해 상속으로 개선

## 🙏 리뷰 요구사항
- 잠수함 패치로 `@ActiveProfiles("test")`를 추가하여 H2 데이터베이스를 사용하게 하여 테스트 실행시간 4~5초에서 2~3초로 개선

## 📚 레퍼런스
- 
