### PR TITLE
[WALWAL-169] FCM refresh 메서드 삭제

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/fcm/api/FcmController.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/api/FcmController.java
@@ -51,11 +51,4 @@ public class FcmController {
         fcmTokenService.invalidateToken(fcmTokenRequest.token());
         return ResponseEntity.ok().build();
     }
-
-    @Operation(summary = "앱 실행 시 FCM 토큰 타임스탬프 갱신", description = "앱 실행 시 FCM 토큰의 타임스탬프를 갱신합니다.")
-    @PostMapping("/token/refresh")
-    public ResponseEntity<Void> refreshTokenTimestamp() {
-        fcmTokenService.refreshTokenTimestampForCurrentUser();
-        return ResponseEntity.ok().build();
-    }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmTokenService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmTokenService.java
@@ -57,16 +57,4 @@ public class FcmTokenService {
                     fcmRepository.save(fcmToken);
                 });
     }
-
-    @Transactional
-    public void refreshTokenTimestampForCurrentUser() {
-        final Member member = memberUtil.getCurrentMember();
-        fcmRepository
-                .findByMember(member)
-                .ifPresentOrElse(
-                        fcmToken -> updateToken(fcmToken, fcmToken.getToken()),
-                        () -> {
-                            throw new CustomException(ErrorCode.FAILED_TO_FIND_FCM_TOKEN);
-                        });
-    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #114 

## 📌 작업 내용
- 로그인 이후에 FCM토큰을 저장하는 과정에서, 네트워크 오류 등 엣지케이스로 토큰 저장에 실패하면 이후에 토큰을 관리하는 과정에서, 앱 실행 시 마다 refresh해주는 api의 사용 목적이기 때문에 앱을 접속 할 때 마다 FCM토큰을 새로 저장해주는 로직(/alarm/token)을 사용하기로 함.
- /token/refresh 메서드 삭제

## 🙏 리뷰 요구사항
- /alarm/token API로 통일하여 기존 타임스탬프관리용도인 /alarm/token/refresh API 삭제했습니다.

## 📚 레퍼런스
- 
