### PR TITLE
refactor: 다른 유저 캘린더 조회 및 GET 요청으로 변경

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/api/MissionRecordController.java
@@ -1,14 +1,16 @@
 package com.depromeet.stonebed.domain.missionRecord.api;
 
 import com.depromeet.stonebed.domain.missionRecord.application.MissionRecordService;
-import com.depromeet.stonebed.domain.missionRecord.dto.request.MissionRecordCalendarRequest;
 import com.depromeet.stonebed.domain.missionRecord.dto.request.MissionRecordSaveRequest;
 import com.depromeet.stonebed.domain.missionRecord.dto.request.MissionRecordStartRequest;
 import com.depromeet.stonebed.domain.missionRecord.dto.response.MissionRecordCalendarResponse;
 import com.depromeet.stonebed.domain.missionRecord.dto.response.MissionTabResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -49,10 +51,24 @@ public class MissionRecordController {
     }
 
     @Operation(summary = "캘린더 형식의 미션 기록 조회", description = "회원의 미션 기록을 페이징하여 조회한다.")
-    @PostMapping("/calendar")
+    @GetMapping("/calendar")
     public MissionRecordCalendarResponse getMissionRecordsForCalendar(
-            @Valid @RequestBody MissionRecordCalendarRequest request) {
-        return missionRecordService.getMissionRecordsForCalendar(request.cursor(), request.limit());
+            @Parameter(description = "커서 위치", example = "2024-01-01")
+                    @Valid
+                    @RequestParam(required = false)
+                    String cursor,
+            @Parameter(description = "페이지 당 항목 수", example = "30")
+                    @Valid
+                    @RequestParam
+                    @NotNull
+                    @Min(1)
+                    int limit,
+            @Parameter(description = "조회할 memberId", example = "1")
+                    @Valid
+                    @RequestParam(required = false)
+                    Long memberId) {
+
+        return missionRecordService.getMissionRecordsForCalendar(cursor, limit, memberId);
     }
 
     @Operation(summary = "수행한 총 미션 기록 수", description = "회원이 수행한 총 미션 기록 수를 조회한다.")

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordService.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -89,31 +90,39 @@ public class MissionRecordService {
     }
 
     @Transactional(readOnly = true)
-    public MissionRecordCalendarResponse getMissionRecordsForCalendar(String cursor, int limit) {
-        final Member member = memberUtil.getCurrentMember();
-        Pageable pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.ASC, "createdAt"));
+    public MissionRecordCalendarResponse getMissionRecordsForCalendar(
+            String cursor, int limit, Long memberId) {
+        Long findMemberId =
+                Optional.ofNullable(memberId)
+                        .orElseGet(() -> memberUtil.getCurrentMember().getId());
 
-        List<MissionRecord> records = getMissionRecords(cursor, member, pageable);
-
-        List<MissionRecordCalendarDto> calendarData =
-                records.stream()
-                        .map(record -> MissionRecordCalendarDto.from(record, DATE_FORMATTER))
-                        .toList();
-
+        Pageable pageable = createPageable(limit);
+        List<MissionRecord> records = getMissionRecords(cursor, findMemberId, pageable);
+        List<MissionRecordCalendarDto> calendarData = convertToCalendarDto(records);
         String nextCursor = getNextCursor(records);
 
         return MissionRecordCalendarResponse.from(calendarData, nextCursor);
     }
 
-    private List<MissionRecord> getMissionRecords(String cursor, Member member, Pageable pageable) {
+    private Pageable createPageable(int limit) {
+        return PageRequest.of(0, limit, Sort.by(Sort.Direction.ASC, "createdAt"));
+    }
+
+    private List<MissionRecordCalendarDto> convertToCalendarDto(List<MissionRecord> records) {
+        return records.stream()
+                .map(record -> MissionRecordCalendarDto.from(record, DATE_FORMATTER))
+                .toList();
+    }
+
+    private List<MissionRecord> getMissionRecords(String cursor, Long memberId, Pageable pageable) {
         if (cursor == null) {
-            return missionRecordRepository.findByMemberIdWithPagination(member.getId(), pageable);
+            return missionRecordRepository.findByMemberIdWithPagination(memberId, pageable);
         }
 
         try {
             LocalDateTime cursorDate = LocalDate.parse(cursor, DATE_FORMATTER).atStartOfDay();
             return missionRecordRepository.findByMemberIdAndCreatedAtFromWithPagination(
-                    member.getId(), cursorDate, pageable);
+                    memberId, cursorDate, pageable);
         } catch (DateTimeParseException e) {
             throw new CustomException(ErrorCode.INVALID_CURSOR_DATE_FORMAT);
         }

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dto/request/MissionRecordCalendarRequest.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dto/request/MissionRecordCalendarRequest.java
@@ -1,9 +1,0 @@
-package com.depromeet.stonebed.domain.missionRecord.dto.request;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-
-public record MissionRecordCalendarRequest(
-        @Schema(description = "커서 위치", example = "2024-01-01") String cursor,
-        @NotNull @Min(1) @Schema(description = "페이지 당 항목 수", example = "30") int limit) {}

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dto/response/MissionRecordCalendarResponse.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dto/response/MissionRecordCalendarResponse.java
@@ -7,7 +7,7 @@ public record MissionRecordCalendarResponse(
         @Schema(
                         description = "미션 기록 데이터 리스트",
                         example =
-                                "[{ 'imageId': 1, 'imageUrl': 'http://example.com/image1.jpg', 'missionDate': '2024-01-01' }]")
+                                "[{\"imageId\": 1, \"imageUrl\": \"http://example.com/image1.jpg\", \"missionDate\": \"2024-01-01\"}]")
                 List<MissionRecordCalendarDto> list,
         @Schema(description = "커서 위치", example = "2024-01-03") String nextCursor) {
 

--- a/src/test/java/com/depromeet/stonebed/domain/missionRecord/MissionRecordServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/missionRecord/MissionRecordServiceTest.java
@@ -111,7 +111,7 @@ class MissionRecordServiceTest extends FixtureMonkeySetUp {
     }
 
     @Test
-    void 캘린더미션기록조회_성공() {
+    void 본인의_미션_기록_캘린더를_조회합니다() {
         // given
         Member member = fixtureMonkey.giveMeOne(Member.class);
         List<MissionRecord> missionRecords = fixtureMonkey.giveMe(MissionRecord.class, 5);
@@ -125,13 +125,40 @@ class MissionRecordServiceTest extends FixtureMonkeySetUp {
 
         // when
         MissionRecordCalendarResponse response =
-                missionRecordService.getMissionRecordsForCalendar(cursor, limit);
+                missionRecordService.getMissionRecordsForCalendar(
+                        cursor, limit, null); // Pass null for memberId
 
         // then
         then(response).isNotNull();
         then(response.list()).isNotEmpty();
 
-        verify(memberUtil).getCurrentMember();
+        verify(memberUtil).getCurrentMember(); // This will now be invoked
+        verify(missionRecordRepository)
+                .findByMemberIdWithPagination(
+                        member.getId(),
+                        PageRequest.of(0, limit, Sort.by(Sort.Direction.ASC, "createdAt")));
+    }
+
+    @Test
+    void 다른_사용자의_미션_기록_캘린더를_조회합니다() {
+        // given
+        Member member = fixtureMonkey.giveMeOne(Member.class);
+        List<MissionRecord> missionRecords = fixtureMonkey.giveMe(MissionRecord.class, 5);
+
+        when(missionRecordRepository.findByMemberIdWithPagination(anyLong(), any(Pageable.class)))
+                .thenReturn(missionRecords);
+
+        String cursor = null;
+        int limit = 5;
+
+        // when
+        MissionRecordCalendarResponse response =
+                missionRecordService.getMissionRecordsForCalendar(cursor, limit, member.getId());
+
+        // then
+        then(response).isNotNull();
+        then(response.list()).isNotEmpty();
+
         verify(missionRecordRepository)
                 .findByMemberIdWithPagination(
                         member.getId(),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #129 

## 📌 작업 내용
- 캘린더 뷰 조회 방식을 POST -> GET으로 변경
- Request Body가 아닌 QueryString으로 RequestParam을 사용
- 다른 사용자의 캘린더 뷰를 조회할 수 있도록 memberId 인자 추가

## 🙏 리뷰 요구사항
-

## 📚 레퍼런스
- 
