### PR TITLE
[WALWAL-173] fcm alarm list 구현 

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/fcm/api/FcmController.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/api/FcmController.java
@@ -10,7 +10,9 @@ import com.depromeet.stonebed.global.util.FcmNotificationUtil;
 import com.google.firebase.messaging.Notification;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "6. [알림]", description = "알림 관련 API입니다.")
@@ -57,10 +60,12 @@ public class FcmController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "FCM 알림 리스트 조회", description = "알림 탭에서의 알림 리스트를 조회합니다.")
+    @Operation(summary = "알림 리스트 조회", description = "회원의 알림을 커서 기반으로 페이징하여 조회한다.")
     @GetMapping
-    public List<FcmNotificationResponse> getNotifications() {
-        return fcmNotificationService.getNotificationsForCurrentMember();
+    public FcmNotificationResponse getNotifications(
+            @Valid @RequestParam(name = "cursor", required = false) String cursor,
+            @Valid @NotNull @Min(1) @RequestParam(name = "limit", defaultValue = "10") int limit) {
+        return fcmNotificationService.getNotificationsForCurrentMember(cursor, limit);
     }
 
     @Operation(summary = "FCM 알림 읽음 처리", description = "알림을 읽음 상태로 변경합니다.")

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/api/FcmController.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/api/FcmController.java
@@ -1,17 +1,22 @@
 package com.depromeet.stonebed.domain.fcm.api;
 
+import com.depromeet.stonebed.domain.fcm.application.FcmNotificationService;
 import com.depromeet.stonebed.domain.fcm.application.FcmService;
 import com.depromeet.stonebed.domain.fcm.application.FcmTokenService;
 import com.depromeet.stonebed.domain.fcm.dto.request.FcmSendRequest;
 import com.depromeet.stonebed.domain.fcm.dto.request.FcmTokenRequest;
+import com.depromeet.stonebed.domain.fcm.dto.response.FcmNotificationResponse;
 import com.depromeet.stonebed.global.util.FcmNotificationUtil;
 import com.google.firebase.messaging.Notification;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FcmController {
     private final FcmService fcmService;
     private final FcmTokenService fcmTokenService;
+    private final FcmNotificationService fcmNotificationService;
 
     @Operation(summary = "푸시 메시지 전송", description = "저장된 모든 토큰에 푸시 메시지를 전송합니다.")
     @PostMapping("/send")
@@ -49,6 +55,20 @@ public class FcmController {
     public ResponseEntity<Void> deleteToken(
             @RequestBody @Validated FcmTokenRequest fcmTokenRequest) {
         fcmTokenService.invalidateToken(fcmTokenRequest.token());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "FCM 알림 리스트 조회", description = "알림 탭에서의 알림 리스트를 조회합니다.")
+    @GetMapping
+    public List<FcmNotificationResponse> getNotifications() {
+        return fcmNotificationService.getNotificationsForCurrentMember();
+    }
+
+    @Operation(summary = "FCM 알림 읽음 처리", description = "알림을 읽음 상태로 변경합니다.")
+    @PostMapping("/{notificationId}/read")
+    public ResponseEntity<Void> markNotificationAsRead(
+            @PathVariable("notificationId") Long notificationId) {
+        fcmNotificationService.markNotificationAsRead(notificationId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationService.java
@@ -1,0 +1,95 @@
+package com.depromeet.stonebed.domain.fcm.application;
+
+import com.depromeet.stonebed.domain.fcm.dao.FcmNotificationRepository;
+import com.depromeet.stonebed.domain.fcm.dao.FcmRepository;
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotification;
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotificationType;
+import com.depromeet.stonebed.domain.fcm.dto.response.FcmNotificationResponse;
+import com.depromeet.stonebed.domain.member.domain.Member;
+import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordBoostRepository;
+import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.stonebed.global.error.ErrorCode;
+import com.depromeet.stonebed.global.error.exception.CustomException;
+import com.depromeet.stonebed.global.util.FcmNotificationUtil;
+import com.depromeet.stonebed.global.util.MemberUtil;
+import com.google.firebase.messaging.Notification;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FcmNotificationService {
+    private final FcmService fcmService;
+    private final FcmNotificationRepository notificationRepository;
+    private final MissionRecordBoostRepository missionRecordBoostRepository;
+    private final FcmRepository fcmRepository;
+    private final MemberUtil memberUtil;
+
+    public void saveNotification(
+            FcmNotificationType type,
+            String title,
+            String message,
+            String imageUrl,
+            Long targetId,
+            Boolean isRead) {
+        final Member member = memberUtil.getCurrentMember();
+
+        FcmNotification notification =
+                new FcmNotification(type, title, message, imageUrl, member, targetId, isRead);
+        notificationRepository.save(notification);
+    }
+
+    public List<FcmNotificationResponse> getNotificationsForCurrentMember() {
+        final Member member = memberUtil.getCurrentMember();
+        return notificationRepository.findAllByMember(member).stream()
+                .map(FcmNotificationResponse::from)
+                .toList();
+    }
+
+    public void checkAndSendBoostNotification(MissionRecord missionRecord) {
+        Long totalBoostCount =
+                missionRecordBoostRepository.sumBoostCountByMissionRecord(missionRecord.getId());
+        Long recordId = missionRecord.getId();
+        String imageUrl = missionRecord.getImageUrl();
+        if (totalBoostCount != null) {
+            String title = "";
+            String message = "";
+
+            if (totalBoostCount == 500) {
+                title = "인기쟁이";
+                message = "게시물 부스터를 500개를 달성했어요!";
+            } else if (totalBoostCount == 5000) {
+                title = "최고 인기 달성";
+                message = "인기폭발! 부스터를 5000개 달성했어요!";
+            }
+
+            if (!title.isEmpty()) {
+                Notification notification = FcmNotificationUtil.buildNotification(title, message);
+
+                String token =
+                        fcmRepository
+                                .findByMember(missionRecord.getMember())
+                                .orElseThrow()
+                                .getToken();
+                fcmService.sendSingleMessage(notification, token);
+
+                saveNotification(
+                        FcmNotificationType.BOOSTER, title, message, imageUrl, recordId, false);
+            }
+        }
+    }
+
+    @Transactional
+    public void markNotificationAsRead(Long notificationId) {
+        final Member member = memberUtil.getCurrentMember();
+        FcmNotification notification =
+                notificationRepository
+                        .findByIdAndMember(notificationId, member)
+                        .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        notification.markAsRead();
+        notificationRepository.save(notification);
+    }
+}

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledService.java
@@ -47,7 +47,7 @@ public class FcmScheduledService {
                 FcmNotificationType.MISSION, title, message, null, null, false);
     }
 
-    // 매일 18시 0분에 실행
+    // 매일 19시 0분에 실행
     @Scheduled(cron = "0 0 19 * * ?")
     public void sendReminderToIncompleteMissions() {
         String title = "미션 리마인드";

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledService.java
@@ -1,6 +1,7 @@
 package com.depromeet.stonebed.domain.fcm.application;
 
 import com.depromeet.stonebed.domain.fcm.dao.FcmRepository;
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotificationType;
 import com.depromeet.stonebed.domain.fcm.domain.FcmToken;
 import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordStatus;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class FcmScheduledService {
     private final FcmService fcmService;
+    private final FcmNotificationService fcmNotificationService;
     private final FcmRepository fcmRepository;
     private final MissionRecordRepository missionRecordRepository;
 
@@ -31,22 +33,33 @@ public class FcmScheduledService {
         log.info("비활성 토큰 {}개 삭제 완료", inactiveTokens.size());
     }
 
-    // 매일 12시 0분에 실행
-    @Scheduled(cron = "0 0 12 * * ?")
+    // 매일 9시 0분에 실행
+    @Scheduled(cron = "0 0 9 * * ?")
     public void sendDailyNotification() {
-        Notification notification = FcmNotificationUtil.buildNotification("정규 메세지 제목", "정규 메세지 내용");
+        String title = "미션 시작!";
+        String message = "새로운 미션을 지금 시작해보세요!";
+        Notification notification = FcmNotificationUtil.buildNotification(title, message);
+
         fcmService.sendMulticastMessageToAll(notification);
         log.info("모든 사용자에게 정규 알림 전송 완료");
+
+        fcmNotificationService.saveNotification(
+                FcmNotificationType.MISSION, title, message, null, null, false);
     }
 
     // 매일 18시 0분에 실행
-    @Scheduled(cron = "0 0 18 * * ?")
+    @Scheduled(cron = "0 0 19 * * ?")
     public void sendReminderToIncompleteMissions() {
-        Notification notification =
-                FcmNotificationUtil.buildNotification("리마인드 메세지 제목", "리마인드 메세지 내용");
+        String title = "미션 리마인드";
+        String message = "미션 종료까지 5시간 남았어요!";
+        Notification notification = FcmNotificationUtil.buildNotification(title, message);
+
         List<String> tokens = getIncompleteMissionTokens();
         fcmService.sendMulticastMessage(notification, tokens);
         log.info("미완료 미션 사용자에게 리마인더 전송 완료. 총 토큰 수: {}", tokens.size());
+
+        fcmNotificationService.saveNotification(
+                FcmNotificationType.MISSION, title, message, null, null, false);
     }
 
     private List<String> getIncompleteMissionTokens() {

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledService.java
@@ -50,7 +50,6 @@ public class FcmScheduledService {
                 notificationConstants.getTitle(),
                 notificationConstants.getMessage(),
                 null,
-                null,
                 false);
     }
 
@@ -70,7 +69,6 @@ public class FcmScheduledService {
                 FcmNotificationType.MISSION,
                 notificationConstants.getTitle(),
                 notificationConstants.getMessage(),
-                null,
                 null,
                 false);
     }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledService.java
@@ -5,6 +5,7 @@ import com.depromeet.stonebed.domain.fcm.domain.FcmNotificationType;
 import com.depromeet.stonebed.domain.fcm.domain.FcmToken;
 import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordStatus;
+import com.depromeet.stonebed.global.common.constants.FcmNotificationConstants;
 import com.depromeet.stonebed.global.util.FcmNotificationUtil;
 import com.google.firebase.messaging.Notification;
 import java.time.LocalDateTime;
@@ -36,30 +37,42 @@ public class FcmScheduledService {
     // 매일 9시 0분에 실행
     @Scheduled(cron = "0 0 9 * * ?")
     public void sendDailyNotification() {
-        String title = "미션 시작!";
-        String message = "새로운 미션을 지금 시작해보세요!";
-        Notification notification = FcmNotificationUtil.buildNotification(title, message);
+        FcmNotificationConstants notificationConstants = FcmNotificationConstants.MISSION_START;
+        Notification notification =
+                FcmNotificationUtil.buildNotification(
+                        notificationConstants.getTitle(), notificationConstants.getMessage());
 
         fcmService.sendMulticastMessageToAll(notification);
         log.info("모든 사용자에게 정규 알림 전송 완료");
 
         fcmNotificationService.saveNotification(
-                FcmNotificationType.MISSION, title, message, null, null, false);
+                FcmNotificationType.MISSION,
+                notificationConstants.getTitle(),
+                notificationConstants.getMessage(),
+                null,
+                null,
+                false);
     }
 
     // 매일 19시 0분에 실행
     @Scheduled(cron = "0 0 19 * * ?")
     public void sendReminderToIncompleteMissions() {
-        String title = "미션 리마인드";
-        String message = "미션 종료까지 5시간 남았어요!";
-        Notification notification = FcmNotificationUtil.buildNotification(title, message);
+        FcmNotificationConstants notificationConstants = FcmNotificationConstants.MISSION_REMINDER;
+        Notification notification =
+                FcmNotificationUtil.buildNotification(
+                        notificationConstants.getTitle(), notificationConstants.getMessage());
 
         List<String> tokens = getIncompleteMissionTokens();
         fcmService.sendMulticastMessage(notification, tokens);
         log.info("미완료 미션 사용자에게 리마인더 전송 완료. 총 토큰 수: {}", tokens.size());
 
         fcmNotificationService.saveNotification(
-                FcmNotificationType.MISSION, title, message, null, null, false);
+                FcmNotificationType.MISSION,
+                notificationConstants.getTitle(),
+                notificationConstants.getMessage(),
+                null,
+                null,
+                false);
     }
 
     private List<String> getIncompleteMissionTokens() {

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmService.java
@@ -54,7 +54,7 @@ public class FcmService {
                 .build();
     }
 
-    public void sendMessage(MulticastMessage message, List<String> tokens) {
+    private void sendMessage(MulticastMessage message, List<String> tokens) {
         try {
             BatchResponse response = FirebaseMessaging.getInstance().sendMulticast(message);
             handleBatchResponse(response, tokens);
@@ -63,7 +63,7 @@ public class FcmService {
         }
     }
 
-    public void sendMessage(Message message) {
+    private void sendMessage(Message message) {
         try {
             String response = FirebaseMessaging.getInstance().send(message);
             log.info("성공적으로 메시지를 전송했습니다. 메시지 ID: {}", response);

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmService.java
@@ -54,13 +54,37 @@ public class FcmService {
                 .build();
     }
 
-    private void sendMessage(MulticastMessage message, List<String> tokens) {
+    public void sendMessage(MulticastMessage message, List<String> tokens) {
         try {
             BatchResponse response = FirebaseMessaging.getInstance().sendMulticast(message);
             handleBatchResponse(response, tokens);
         } catch (FirebaseMessagingException e) {
             log.error("FCM 메시지 전송에 실패했습니다: ", e);
         }
+    }
+
+    public void sendMessage(Message message) {
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("성공적으로 메시지를 전송했습니다. 메시지 ID: {}", response);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 메시지 전송에 실패했습니다: ", e);
+        }
+    }
+
+    public void sendSingleMessage(Notification notification, String token) {
+        Message message = buildSingleMessage(notification, token);
+        sendMessage(message);
+    }
+
+    private Message buildSingleMessage(Notification notification, String token) {
+        HashMap<String, String> data = new HashMap<>();
+
+        return Message.builder()
+                .putAllData(data)
+                .setNotification(notification)
+                .setToken(token)
+                .build();
     }
 
     private void handleBatchResponse(BatchResponse response, List<String> tokens) {

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmNotificationRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmNotificationRepository.java
@@ -2,12 +2,17 @@ package com.depromeet.stonebed.domain.fcm.dao;
 
 import com.depromeet.stonebed.domain.fcm.domain.FcmNotification;
 import com.depromeet.stonebed.domain.member.domain.Member;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FcmNotificationRepository extends JpaRepository<FcmNotification, Long> {
-    List<FcmNotification> findAllByMember(Member member);
+    List<FcmNotification> findByMemberId(Long memberId, Pageable pageable);
+
+    List<FcmNotification> findByMemberIdAndCreatedAtLessThanEqual(
+            Long memberId, LocalDateTime cursorDate, Pageable pageable);
 
     Optional<FcmNotification> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmNotificationRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmNotificationRepository.java
@@ -1,0 +1,13 @@
+package com.depromeet.stonebed.domain.fcm.dao;
+
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotification;
+import com.depromeet.stonebed.domain.member.domain.Member;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FcmNotificationRepository extends JpaRepository<FcmNotification, Long> {
+    List<FcmNotification> findAllByMember(Member member);
+
+    Optional<FcmNotification> findByIdAndMember(Long id, Member member);
+}

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
@@ -26,8 +26,6 @@ public class FcmNotification extends BaseTimeEntity {
     @Column(nullable = false)
     private String message;
 
-    @Column private String notificationImageUrl;
-
     @Column private Long targetId;
 
     @Column(nullable = false)
@@ -41,14 +39,12 @@ public class FcmNotification extends BaseTimeEntity {
             FcmNotificationType type,
             String title,
             String message,
-            String notificationImageUrl,
             Member member,
             Long targetId,
             Boolean isRead) {
         this.type = type;
         this.title = title;
         this.message = message;
-        this.notificationImageUrl = notificationImageUrl;
         this.member = member;
         this.targetId = targetId;
         this.isRead = isRead;
@@ -58,12 +54,10 @@ public class FcmNotification extends BaseTimeEntity {
             FcmNotificationType type,
             String title,
             String message,
-            String notificationImageUrl,
             Member member,
             Long targetId,
             Boolean isRead) {
-        return new FcmNotification(
-                type, title, message, notificationImageUrl, member, targetId, isRead);
+        return new FcmNotification(type, title, message, member, targetId, isRead);
     }
 
     public void markAsRead() {

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
@@ -37,7 +37,7 @@ public class FcmNotification extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    public FcmNotification(
+    private FcmNotification(
             FcmNotificationType type,
             String title,
             String message,
@@ -52,6 +52,18 @@ public class FcmNotification extends BaseTimeEntity {
         this.member = member;
         this.targetId = targetId;
         this.isRead = isRead;
+    }
+
+    public static FcmNotification create(
+            FcmNotificationType type,
+            String title,
+            String message,
+            String notificationImageUrl,
+            Member member,
+            Long targetId,
+            Boolean isRead) {
+        return new FcmNotification(
+                type, title, message, notificationImageUrl, member, targetId, isRead);
     }
 
     public void markAsRead() {

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
@@ -1,0 +1,60 @@
+package com.depromeet.stonebed.domain.fcm.domain;
+
+import com.depromeet.stonebed.domain.common.BaseTimeEntity;
+import com.depromeet.stonebed.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FcmNotification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FcmNotificationType type;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Column private String notificationImageUrl;
+
+    @Column private Long targetId;
+
+    @Column(nullable = false)
+    private Boolean isRead = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    public FcmNotification(
+            FcmNotificationType type,
+            String title,
+            String message,
+            String notificationImageUrl,
+            Member member,
+            Long targetId,
+            Boolean isRead) {
+        this.type = type;
+        this.title = title;
+        this.message = message;
+        this.notificationImageUrl = notificationImageUrl;
+        this.member = member;
+        this.targetId = targetId;
+        this.isRead = isRead;
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotificationType.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotificationType.java
@@ -10,8 +10,4 @@ public enum FcmNotificationType {
     BOOSTER("부스터 알림");
 
     private final String value;
-
-    public String getValue() {
-        return value;
-    }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotificationType.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotificationType.java
@@ -1,0 +1,17 @@
+package com.depromeet.stonebed.domain.fcm.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FcmNotificationType {
+    MISSION("미션 알림"),
+    BOOSTER("부스터 알림");
+
+    private final String value;
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationDto.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationDto.java
@@ -1,0 +1,35 @@
+package com.depromeet.stonebed.domain.fcm.dto.response;
+
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotification;
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotificationType;
+import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record FcmNotificationDto(
+        @Schema(description = "알림 ID", example = "1") Long notificationId,
+        @Schema(description = "알림 타입", example = "MISSION") FcmNotificationType type,
+        @Schema(description = "알림 제목", example = "미션 완료 알림") String title,
+        @Schema(description = "알림 내용", example = "미션이 성공적으로 완료되었습니다.") String message,
+        @Schema(description = "알림 이미지 URL", example = "https://example.com/image.jpg")
+                String imageUrl,
+        @Schema(description = "읽음 여부", example = "false") Boolean isRead,
+        @Schema(description = "타겟 ID", example = "1") Long targetId,
+        @Schema(description = "알림 전송 시간", example = "2024-08-17 13:31:19")
+                LocalDateTime createdAt) {
+
+    public static FcmNotificationDto from(
+            FcmNotification notification, MissionRecord missionRecord) {
+        String imageUrl = missionRecord != null ? missionRecord.getImageUrl() : null;
+
+        return new FcmNotificationDto(
+                notification.getId(),
+                notification.getType(),
+                notification.getTitle(),
+                notification.getMessage(),
+                imageUrl,
+                notification.getIsRead(),
+                notification.getTargetId(),
+                notification.getCreatedAt());
+    }
+}

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationResponse.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationResponse.java
@@ -3,6 +3,7 @@ package com.depromeet.stonebed.domain.fcm.dto.response;
 import com.depromeet.stonebed.domain.fcm.domain.FcmNotification;
 import com.depromeet.stonebed.domain.fcm.domain.FcmNotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 
 public record FcmNotificationResponse(
         @Schema(description = "알림 ID", example = "1") Long notificationId,
@@ -12,7 +13,10 @@ public record FcmNotificationResponse(
         @Schema(description = "알림 이미지 URL", example = "https://example.com/image.jpg")
                 String imageUrl,
         @Schema(description = "읽음 여부", example = "false") Boolean isRead,
-        @Schema(description = "타겟 ID", example = "1") Long targetId) {
+        @Schema(description = "타겟 ID", example = "1") Long targetId,
+        @Schema(description = "알림 전송 시간", example = "2024-08-17 13:31:19")
+                LocalDateTime createdAt) {
+
     public static FcmNotificationResponse from(FcmNotification notification) {
         return new FcmNotificationResponse(
                 notification.getId(),
@@ -21,6 +25,7 @@ public record FcmNotificationResponse(
                 notification.getMessage(),
                 notification.getNotificationImageUrl(),
                 notification.getIsRead(),
-                notification.getTargetId());
+                notification.getTargetId(),
+                notification.getCreatedAt());
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationResponse.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationResponse.java
@@ -1,35 +1,13 @@
 package com.depromeet.stonebed.domain.fcm.dto.response;
 
-import com.depromeet.stonebed.domain.fcm.domain.FcmNotification;
-import com.depromeet.stonebed.domain.fcm.domain.FcmNotificationType;
-import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
+import java.util.List;
 
 public record FcmNotificationResponse(
-        @Schema(description = "알림 ID", example = "1") Long notificationId,
-        @Schema(description = "알림 타입", example = "MISSION") FcmNotificationType type,
-        @Schema(description = "알림 제목", example = "미션 완료 알림") String title,
-        @Schema(description = "알림 내용", example = "미션이 성공적으로 완료되었습니다.") String message,
-        @Schema(description = "알림 이미지 URL", example = "https://example.com/image.jpg")
-                String imageUrl,
-        @Schema(description = "읽음 여부", example = "false") Boolean isRead,
-        @Schema(description = "타겟 ID", example = "1") Long targetId,
-        @Schema(description = "알림 전송 시간", example = "2024-08-17 13:31:19")
-                LocalDateTime createdAt) {
+        @Schema(description = "알림 리스트") List<FcmNotificationDto> list,
+        @Schema(description = "다음 커서 위치", example = "2024-08-17T13:31:19") String nextCursor) {
 
-    public static FcmNotificationResponse from(
-            FcmNotification notification, MissionRecord missionRecord) {
-        String imageUrl = missionRecord != null ? missionRecord.getImageUrl() : null;
-
-        return new FcmNotificationResponse(
-                notification.getId(),
-                notification.getType(),
-                notification.getTitle(),
-                notification.getMessage(),
-                imageUrl,
-                notification.getIsRead(),
-                notification.getTargetId(),
-                notification.getCreatedAt());
+    public static FcmNotificationResponse from(List<FcmNotificationDto> list, String nextCursor) {
+        return new FcmNotificationResponse(list, nextCursor);
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationResponse.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationResponse.java
@@ -2,6 +2,7 @@ package com.depromeet.stonebed.domain.fcm.dto.response;
 
 import com.depromeet.stonebed.domain.fcm.domain.FcmNotification;
 import com.depromeet.stonebed.domain.fcm.domain.FcmNotificationType;
+import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
@@ -17,13 +18,16 @@ public record FcmNotificationResponse(
         @Schema(description = "알림 전송 시간", example = "2024-08-17 13:31:19")
                 LocalDateTime createdAt) {
 
-    public static FcmNotificationResponse from(FcmNotification notification) {
+    public static FcmNotificationResponse from(
+            FcmNotification notification, MissionRecord missionRecord) {
+        String imageUrl = missionRecord != null ? missionRecord.getImageUrl() : null;
+
         return new FcmNotificationResponse(
                 notification.getId(),
                 notification.getType(),
                 notification.getTitle(),
                 notification.getMessage(),
-                notification.getNotificationImageUrl(),
+                imageUrl,
                 notification.getIsRead(),
                 notification.getTargetId(),
                 notification.getCreatedAt());

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationResponse.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationResponse.java
@@ -1,0 +1,26 @@
+package com.depromeet.stonebed.domain.fcm.dto.response;
+
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotification;
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record FcmNotificationResponse(
+        @Schema(description = "알림 ID", example = "1") Long notificationId,
+        @Schema(description = "알림 타입", example = "MISSION") FcmNotificationType type,
+        @Schema(description = "알림 제목", example = "미션 완료 알림") String title,
+        @Schema(description = "알림 내용", example = "미션이 성공적으로 완료되었습니다.") String message,
+        @Schema(description = "알림 이미지 URL", example = "https://example.com/image.jpg")
+                String imageUrl,
+        @Schema(description = "읽음 여부", example = "false") Boolean isRead,
+        @Schema(description = "타겟 ID", example = "1") Long targetId) {
+    public static FcmNotificationResponse from(FcmNotification notification) {
+        return new FcmNotificationResponse(
+                notification.getId(),
+                notification.getType(),
+                notification.getTitle(),
+                notification.getMessage(),
+                notification.getNotificationImageUrl(),
+                notification.getIsRead(),
+                notification.getTargetId());
+    }
+}

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/api/MissionRecordController.java
@@ -83,7 +83,7 @@ public class MissionRecordController {
     @Operation(summary = "부스트 생성", description = "미션 기록에 부스트를 생성한다.")
     @PostMapping("/{recordId}/boost")
     public ResponseEntity<Void> postFeed(
-            @PathVariable Long recordId,
+            @PathVariable("recordId") Long recordId,
             final @Valid @RequestBody MissionRecordBoostRequest request) {
         missionRecordService.createBoost(recordId, request.count());
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordService.java
@@ -1,5 +1,6 @@
 package com.depromeet.stonebed.domain.missionRecord.application;
 
+import com.depromeet.stonebed.domain.fcm.application.FcmNotificationService;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.domain.mission.dao.missionHistory.MissionHistoryRepository;
 import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
@@ -32,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class MissionRecordService {
-
+    private final FcmNotificationService fcmNotificationService;
     private final MissionRecordRepository missionRecordRepository;
     private final MissionHistoryRepository missionHistoryRepository;
     private final MissionRecordBoostRepository missionRecordBoostRepository;
@@ -102,6 +103,8 @@ public class MissionRecordService {
                         .build();
 
         missionRecordBoostRepository.save(missionRecordBoost);
+
+        fcmNotificationService.checkAndSendBoostNotification(missionRecord);
     }
 
     private MissionHistory findMissionHistoryById(Long missionId) {

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordBoostRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordBoostRepository.java
@@ -2,5 +2,11 @@ package com.depromeet.stonebed.domain.missionRecord.dao;
 
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordBoost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface MissionRecordBoostRepository extends JpaRepository<MissionRecordBoost, Long> {}
+public interface MissionRecordBoostRepository extends JpaRepository<MissionRecordBoost, Long> {
+    @Query(
+            "SELECT SUM(mrb.count) FROM MissionRecordBoost mrb WHERE mrb.missionRecord.id = :missionRecordId")
+    Long sumBoostCountByMissionRecord(@Param("missionRecordId") Long missionRecordId);
+}

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepository.java
@@ -16,4 +16,6 @@ public interface MissionRecordRepository
     Long countByMemberIdAndStatus(Long memberId, MissionRecordStatus status);
 
     List<MissionRecord> findAllByStatus(MissionRecordStatus status);
+
+    List<MissionRecord> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/depromeet/stonebed/global/common/constants/FcmNotificationConstants.java
+++ b/src/main/java/com/depromeet/stonebed/global/common/constants/FcmNotificationConstants.java
@@ -1,0 +1,16 @@
+package com.depromeet.stonebed.global.common.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FcmNotificationConstants {
+    POPULAR("인기쟁이", "게시물 부스터를 500개를 달성했어요!"),
+    SUPER_POPULAR("최고 인기 달성", "인기폭발! 부스터를 5000개 달성했어요!"),
+    MISSION_START("미션 시작!", "새로운 미션을 지금 시작해보세요!"),
+    MISSION_REMINDER("미션 리마인드", "미션 종료까지 5시간 남았어요!");
+
+    private final String title;
+    private final String message;
+}

--- a/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
+++ b/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
@@ -51,7 +51,8 @@ public enum ErrorCode {
     // fcm
     FAILED_TO_SEND_FCM_MESSAGE(HttpStatus.BAD_REQUEST, "FCM 메세지 전송에 실패했습니다."),
     FAILED_TO_FIND_FCM_TOKEN(HttpStatus.NOT_FOUND, "해당 FCM 토큰을 찾을 수 없습니다."),
-    FIREBASE_CONFIG_NOT_FOUND(HttpStatus.NOT_FOUND, "FIREBASE_CONFIG를 찾을 수 없습니다.");
+    FIREBASE_CONFIG_NOT_FOUND(HttpStatus.NOT_FOUND, "FIREBASE_CONFIG를 찾을 수 없습니다."),
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 알림을 찾을 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
+++ b/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
@@ -49,9 +49,7 @@ public enum ErrorCode {
     FOLLOW_NOT_EXIST(HttpStatus.NOT_FOUND, "팔로우 관계가 존재하지 않습니다."),
 
     // fcm
-    FAILED_TO_SEND_FCM_MESSAGE(HttpStatus.BAD_REQUEST, "FCM 메세지 전송에 실패했습니다."),
     FAILED_TO_FIND_FCM_TOKEN(HttpStatus.NOT_FOUND, "해당 FCM 토큰을 찾을 수 없습니다."),
-    FIREBASE_CONFIG_NOT_FOUND(HttpStatus.NOT_FOUND, "FIREBASE_CONFIG를 찾을 수 없습니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 알림을 찾을 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/depromeet/stonebed/StonebedApplicationTests.java
+++ b/src/test/java/com/depromeet/stonebed/StonebedApplicationTests.java
@@ -1,5 +1,6 @@
 package com.depromeet.stonebed;
 
+import com.depromeet.stonebed.domain.fcm.application.FcmNotificationService;
 import com.google.firebase.messaging.FirebaseMessaging;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -10,6 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class StonebedApplicationTests {
     @MockBean private FirebaseMessaging firebaseMessaging;
+    @MockBean private FcmNotificationService fcmNotificationService;
 
     @Test
     void contextLoads() {}

--- a/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationServiceTest.java
@@ -71,9 +71,9 @@ public class FcmNotificationServiceTest extends FixtureMonkeySetUp {
                 .thenReturn(notifications);
 
         if (fcmNotification.getType() == FcmNotificationType.BOOSTER) {
-            MissionRecord missionRecord = fixtureMonkey.giveMeOne(MissionRecord.class);
-            when(missionRecordRepository.findById(fcmNotification.getTargetId()))
-                    .thenReturn(Optional.of(missionRecord));
+            List<MissionRecord> missionRecords =
+                    List.of(fixtureMonkey.giveMeOne(MissionRecord.class));
+            when(missionRecordRepository.findByIdIn(anyList())).thenReturn(missionRecords);
         }
 
         // when
@@ -85,7 +85,7 @@ public class FcmNotificationServiceTest extends FixtureMonkeySetUp {
         verify(notificationRepository, times(1)).findByMemberId(eq(member.getId()), eq(pageable));
 
         if (fcmNotification.getType() == FcmNotificationType.BOOSTER) {
-            verify(missionRecordRepository, times(1)).findById(fcmNotification.getTargetId());
+            verify(missionRecordRepository, times(1)).findByIdIn(anyList());
         } else {
             verify(missionRecordRepository, times(0)).findById(any());
         }

--- a/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationServiceTest.java
@@ -1,0 +1,110 @@
+package com.depromeet.stonebed.domain.fcm.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.depromeet.stonebed.FixtureMonkeySetUp;
+import com.depromeet.stonebed.domain.fcm.dao.FcmNotificationRepository;
+import com.depromeet.stonebed.domain.fcm.dao.FcmRepository;
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotification;
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotificationType;
+import com.depromeet.stonebed.domain.fcm.dto.response.FcmNotificationResponse;
+import com.depromeet.stonebed.domain.member.domain.Member;
+import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordBoostRepository;
+import com.depromeet.stonebed.global.error.ErrorCode;
+import com.depromeet.stonebed.global.error.exception.CustomException;
+import com.depromeet.stonebed.global.util.MemberUtil;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class FcmNotificationServiceTest extends FixtureMonkeySetUp {
+
+    @Mock private FcmService fcmService;
+    @Mock private FcmNotificationRepository notificationRepository;
+    @Mock private MissionRecordBoostRepository missionRecordBoostRepository;
+    @Mock private FcmRepository fcmRepository;
+    @Mock private MemberUtil memberUtil;
+
+    @InjectMocks private FcmNotificationService fcmNotificationService;
+
+    @Test
+    void 정규알림_응답값_저장() {
+        // given
+        Member member = fixtureMonkey.giveMeOne(Member.class);
+        when(memberUtil.getCurrentMember()).thenReturn(member);
+
+        // when
+        fcmNotificationService.saveNotification(
+                FcmNotificationType.MISSION, "title", "message", "imageUrl", 1L, false);
+
+        // then
+        verify(notificationRepository, times(1)).save(any(FcmNotification.class));
+    }
+
+    @Test
+    void 현재_회원의_알림들_조회() {
+        // given
+        Member member = fixtureMonkey.giveMeOne(Member.class);
+        when(memberUtil.getCurrentMember()).thenReturn(member);
+
+        FcmNotification fcmNotification =
+                fixtureMonkey.giveMeBuilder(FcmNotification.class).set("member", member).sample();
+
+        when(notificationRepository.findAllByMember(member)).thenReturn(List.of(fcmNotification));
+
+        // when
+        List<FcmNotificationResponse> responses =
+                fcmNotificationService.getNotificationsForCurrentMember();
+
+        // then
+        assertTrue(responses.size() > 0);
+        verify(notificationRepository, times(1)).findAllByMember(member);
+    }
+
+    @Test
+    void 알림을_읽음_처리하면_상태가_변경된다() {
+        // given
+        Member member = fixtureMonkey.giveMeOne(Member.class);
+        FcmNotification fcmNotification =
+                fixtureMonkey
+                        .giveMeBuilder(FcmNotification.class)
+                        .set("member", member)
+                        .set("isRead", false)
+                        .sample();
+        when(memberUtil.getCurrentMember()).thenReturn(member);
+        when(notificationRepository.findByIdAndMember(1L, member))
+                .thenReturn(Optional.of(fcmNotification));
+
+        // when
+        fcmNotificationService.markNotificationAsRead(1L);
+
+        // then
+        assertTrue(fcmNotification.getIsRead());
+        verify(notificationRepository, times(1)).save(fcmNotification);
+    }
+
+    @Test
+    void 알림이_존재하지_않으면_예외가_발생한다() {
+        // given
+        Member member = fixtureMonkey.giveMeOne(Member.class);
+        when(memberUtil.getCurrentMember()).thenReturn(member);
+        when(notificationRepository.findByIdAndMember(1L, member)).thenReturn(Optional.empty());
+
+        // when
+        CustomException exception =
+                assertThrows(
+                        CustomException.class,
+                        () -> fcmNotificationService.markNotificationAsRead(1L));
+
+        // then
+        assertTrue(exception.getErrorCode() == ErrorCode.NOTIFICATION_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationServiceTest.java
@@ -43,7 +43,7 @@ public class FcmNotificationServiceTest extends FixtureMonkeySetUp {
 
         // when
         fcmNotificationService.saveNotification(
-                FcmNotificationType.MISSION, "title", "message", "imageUrl", 1L, false);
+                FcmNotificationType.MISSION, "title", "message", 1L, false);
 
         // then
         verify(notificationRepository, times(1)).save(any(FcmNotification.class));

--- a/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledServiceTest.java
@@ -60,12 +60,7 @@ public class FcmScheduledServiceTest extends FixtureMonkeySetUp {
         verify(fcmService, times(1)).sendMulticastMessageToAll(any());
         verify(fcmNotificationService, times(1))
                 .saveNotification(
-                        any(),
-                        eq("미션 시작!"),
-                        eq("새로운 미션을 지금 시작해보세요!"),
-                        isNull(),
-                        isNull(),
-                        eq(false));
+                        any(), eq("미션 시작!"), eq("새로운 미션을 지금 시작해보세요!"), isNull(), eq(false));
     }
 
     @Test
@@ -93,11 +88,6 @@ public class FcmScheduledServiceTest extends FixtureMonkeySetUp {
         verify(fcmService, times(1)).sendMulticastMessage(any(), anyList());
         verify(fcmNotificationService, times(1))
                 .saveNotification(
-                        any(),
-                        eq("미션 리마인드"),
-                        eq("미션 종료까지 5시간 남았어요!"),
-                        isNull(),
-                        isNull(),
-                        eq(false));
+                        any(), eq("미션 리마인드"), eq("미션 종료까지 5시간 남았어요!"), isNull(), eq(false));
     }
 }

--- a/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledServiceTest.java
@@ -9,8 +9,6 @@ import com.depromeet.stonebed.domain.fcm.domain.FcmToken;
 import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordStatus;
-import com.depromeet.stonebed.global.util.FcmNotificationUtil;
-import com.google.firebase.messaging.Notification;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -36,7 +34,6 @@ public class FcmScheduledServiceTest extends FixtureMonkeySetUp {
     @Test
     void 비활성화된_토큰을_삭제하면_정상적으로_삭제된다() {
         // given
-        LocalDateTime cutoffDate = LocalDateTime.now().minusMonths(2);
         List<FcmToken> tokens = fixtureMonkey.giveMe(FcmToken.class, 5);
         when(fcmRepository.findAllByUpdatedAtBefore(any(LocalDateTime.class))).thenReturn(tokens);
 
@@ -56,10 +53,6 @@ public class FcmScheduledServiceTest extends FixtureMonkeySetUp {
 
     @Test
     void 매일_정기_알림을_모든_사용자에게_전송한다() {
-        // given
-        Notification notification =
-                FcmNotificationUtil.buildNotification("미션 시작!", "새로운 미션을 지금 시작해보세요!");
-
         // when
         fcmScheduledService.sendDailyNotification();
 
@@ -78,20 +71,18 @@ public class FcmScheduledServiceTest extends FixtureMonkeySetUp {
     @Test
     void 미완료_미션_사용자에게_리마인더를_전송한다() {
         // given
-        Notification notification =
-                FcmNotificationUtil.buildNotification("미션 리마인드", "미션 종료까지 5시간 남았어요!");
         List<MissionRecord> missionRecords = fixtureMonkey.giveMe(MissionRecord.class, 2);
         when(missionRecordRepository.findAllByStatus(MissionRecordStatus.NOT_COMPLETED))
                 .thenReturn(missionRecords);
 
         missionRecords.forEach(
-                record -> {
+                missionRecord -> {
                     FcmToken token =
                             fixtureMonkey
                                     .giveMeBuilder(FcmToken.class)
-                                    .set("member", record.getMember())
+                                    .set("member", missionRecord.getMember())
                                     .sample();
-                    when(fcmRepository.findByMember(record.getMember()))
+                    when(fcmRepository.findByMember(missionRecord.getMember()))
                             .thenReturn(Optional.of(token));
                 });
 

--- a/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmScheduledServiceTest.java
@@ -1,0 +1,112 @@
+package com.depromeet.stonebed.domain.fcm.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.depromeet.stonebed.FixtureMonkeySetUp;
+import com.depromeet.stonebed.domain.fcm.dao.FcmRepository;
+import com.depromeet.stonebed.domain.fcm.domain.FcmToken;
+import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordRepository;
+import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordStatus;
+import com.depromeet.stonebed.global.util.FcmNotificationUtil;
+import com.google.firebase.messaging.Notification;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class FcmScheduledServiceTest extends FixtureMonkeySetUp {
+
+    @Mock private FcmService fcmService;
+    @Mock private FcmNotificationService fcmNotificationService;
+    @Mock private FcmRepository fcmRepository;
+    @Mock private MissionRecordRepository missionRecordRepository;
+
+    @InjectMocks private FcmScheduledService fcmScheduledService;
+
+    @Test
+    void 비활성화된_토큰을_삭제하면_정상적으로_삭제된다() {
+        // given
+        LocalDateTime cutoffDate = LocalDateTime.now().minusMonths(2);
+        List<FcmToken> tokens = fixtureMonkey.giveMe(FcmToken.class, 5);
+        when(fcmRepository.findAllByUpdatedAtBefore(any(LocalDateTime.class))).thenReturn(tokens);
+
+        // when
+        fcmScheduledService.removeInactiveTokens();
+
+        // then
+        ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(fcmRepository).findAllByUpdatedAtBefore(captor.capture());
+
+        LocalDateTime actualCutoffDate = captor.getValue();
+
+        assertNotNull(actualCutoffDate);
+        assertTrue(actualCutoffDate.isBefore(LocalDateTime.now()));
+        verify(fcmRepository).deleteAll(tokens);
+    }
+
+    @Test
+    void 매일_정기_알림을_모든_사용자에게_전송한다() {
+        // given
+        Notification notification =
+                FcmNotificationUtil.buildNotification("미션 시작!", "새로운 미션을 지금 시작해보세요!");
+
+        // when
+        fcmScheduledService.sendDailyNotification();
+
+        // then
+        verify(fcmService, times(1)).sendMulticastMessageToAll(any());
+        verify(fcmNotificationService, times(1))
+                .saveNotification(
+                        any(),
+                        eq("미션 시작!"),
+                        eq("새로운 미션을 지금 시작해보세요!"),
+                        isNull(),
+                        isNull(),
+                        eq(false));
+    }
+
+    @Test
+    void 미완료_미션_사용자에게_리마인더를_전송한다() {
+        // given
+        Notification notification =
+                FcmNotificationUtil.buildNotification("미션 리마인드", "미션 종료까지 5시간 남았어요!");
+        List<MissionRecord> missionRecords = fixtureMonkey.giveMe(MissionRecord.class, 2);
+        when(missionRecordRepository.findAllByStatus(MissionRecordStatus.NOT_COMPLETED))
+                .thenReturn(missionRecords);
+
+        missionRecords.forEach(
+                record -> {
+                    FcmToken token =
+                            fixtureMonkey
+                                    .giveMeBuilder(FcmToken.class)
+                                    .set("member", record.getMember())
+                                    .sample();
+                    when(fcmRepository.findByMember(record.getMember()))
+                            .thenReturn(Optional.of(token));
+                });
+
+        // when
+        fcmScheduledService.sendReminderToIncompleteMissions();
+
+        // then
+        verify(fcmService, times(1)).sendMulticastMessage(any(), anyList());
+        verify(fcmNotificationService, times(1))
+                .saveNotification(
+                        any(),
+                        eq("미션 리마인드"),
+                        eq("미션 종료까지 5시간 남았어요!"),
+                        isNull(),
+                        isNull(),
+                        eq(false));
+    }
+}

--- a/src/test/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.Mockito.*;
 
 import com.depromeet.stonebed.FixtureMonkeySetUp;
+import com.depromeet.stonebed.domain.fcm.application.FcmNotificationService;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.domain.mission.dao.missionHistory.MissionHistoryRepository;
 import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
@@ -35,7 +36,7 @@ import org.springframework.test.context.ActiveProfiles;
 class MissionRecordServiceTest extends FixtureMonkeySetUp {
 
     @InjectMocks private MissionRecordService missionRecordService;
-
+    @Mock private FcmNotificationService fcmNotificationService;
     @Mock private MissionRecordRepository missionRecordRepository;
     @Mock private MissionHistoryRepository missionHistoryRepository;
     @Mock private MissionRecordBoostRepository missionRecordBoostRepository;

--- a/src/test/java/com/depromeet/stonebed/fixtureMonkeyTest/TestFixtureMonkey.java
+++ b/src/test/java/com/depromeet/stonebed/fixtureMonkeyTest/TestFixtureMonkey.java
@@ -2,6 +2,7 @@ package com.depromeet.stonebed.fixtureMonkeyTest;
 
 import static org.assertj.core.api.BDDAssertions.*;
 
+import com.depromeet.stonebed.domain.fcm.application.FcmNotificationService;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
@@ -16,6 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 class TestFixtureMonkey {
 
     @MockBean private FirebaseMessaging firebaseMessaging;
+    @MockBean private FcmNotificationService fcmNotificationService;
 
     @Test
     void checkPerson() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #135 

## 📌 작업 내용
- 스케쥴러 알림 메세지 전송시 FcmNotification에 저장
- /alarm API 호출 시 알림 리스트 조회
- /{notificationId}/read API 호출 시 알림 읽음 처리

## 🙏 리뷰 요구사항
- 알림 리스트 조회 시 아래의 형식으로 조회되는데 수정사항이나 개선사항있으면 말씀 부탁드려용!
참고로 targetId는 일반 MISSION화면으로 돌아가는 MISSION type의경우 null로 보내고있고, BOOSTER type의경우 해당 피드로돌아가는 recordId를 포함하고있습니다.
```
{
    "success": true,
    "status": 200,
    "data": [
        {
            "notificationId": 1,
            "type": "MISSION",
            "title": "정규 메세지 제목",
            "message": "정규 메세지 내용",
            "imageUrl": null,
            "isRead": true,
            "targetId": null,
            "createdAt": "2024-08-17T11:46:30.376179"
        },
        {
            "notificationId": 4,
            "type": "BOOSTER",
            "title": "인기쟁이",
            "message": "게시물 부스터를 500개를 달성했어요!",
            "imageUrl": null,
            "isRead": false,
            "targetId": 4,
            "createdAt": "2024-08-17T13:42:07.660621"
        }
    ]
}
```

## 📚 레퍼런스
- 
