### PR TITLE
fix: invalidateTokenForCurrentMember메서드 추가 및 수정

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/fcm/api/FcmController.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/api/FcmController.java
@@ -46,9 +46,8 @@ public class FcmController {
 
     @Operation(summary = "FCM 토큰 삭제", description = "로그아웃 시 FCM 토큰을 삭제합니다.")
     @DeleteMapping("/token")
-    public ResponseEntity<Void> deleteToken(
-            @RequestBody @Validated FcmTokenRequest fcmTokenRequest) {
-        fcmTokenService.invalidateToken(fcmTokenRequest.token());
+    public ResponseEntity<Void> deleteToken() {
+        fcmTokenService.invalidateTokenForCurrentMember();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmService.java
@@ -72,6 +72,7 @@ public class FcmService {
                                     tokens.get(response.getResponses().indexOf(sendResponse));
                             if (isInvalidOrNotRegistered(sendResponse)) {
                                 fcmTokenService.invalidateToken(token);
+                                log.warn("FCM 토큰 {}이(가) 유효하지 않거나 등록되지 않았습니다. 토큰을 무효화합니다.", token);
                             }
                         });
     }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmTokenService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmTokenService.java
@@ -28,6 +28,18 @@ public class FcmTokenService {
     }
 
     @Transactional
+    public void invalidateTokenForCurrentMember() {
+        Member currentMember = memberUtil.getCurrentMember();
+        fcmRepository
+                .findByMember(currentMember)
+                .ifPresentOrElse(
+                        fcmToken -> updateToken(fcmToken, ""),
+                        () -> {
+                            throw new CustomException(ErrorCode.FAILED_TO_FIND_FCM_TOKEN);
+                        });
+    }
+
+    @Transactional
     public void invalidateToken(String token) {
         fcmRepository
                 .findByToken(token)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #145 

## 📌 작업 내용
- FCM 토큰 삭제 시 request제거
- invalidateToken메서드, invalidateTokenForCurrentMember메서드로 분리

## 🙏 리뷰 요구사항
-

## 📚 레퍼런스
- 
