### PR TITLE
hotfix: today API before -> after 수정

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/mission/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/mission/MissionRepositoryCustom.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface MissionRepositoryCustom {
     List<Mission> findNotInMissions(List<Mission> missions);
 
-    List<Mission> findMissionsAssignedBefore(LocalDate assignedDate);
+    List<Mission> findMissionsAssignedAfter(LocalDate assignedDate);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/mission/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/mission/MissionRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.depromeet.stonebed.domain.mission.domain.QMission.mission;
 import static com.depromeet.stonebed.domain.mission.domain.QMissionHistory.missionHistory;
 
 import com.depromeet.stonebed.domain.mission.domain.Mission;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
@@ -21,11 +22,15 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
     }
 
     @Override
-    public List<Mission> findMissionsAssignedBefore(LocalDate assignedDate) {
+    public List<Mission> findMissionsAssignedAfter(LocalDate assignedDate) {
         return queryFactory
                 .select(missionHistory.mission)
                 .from(missionHistory)
-                .where(missionHistory.assignedDate.before(assignedDate))
+                .where(assignedDateAfter(assignedDate))
                 .fetch();
+    }
+
+    private BooleanExpression assignedDateAfter(LocalDate assignedDate) {
+        return missionHistory.assignedDate.after(assignedDate);
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/mission/domain/MissionHistory.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/domain/MissionHistory.java
@@ -24,9 +24,13 @@ public class MissionHistory extends BaseTimeEntity {
     @Column(name = "assigned_date", nullable = false, unique = true)
     private LocalDate assignedDate;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     public MissionHistory(Mission mission, LocalDate assignedDate) {
         this.mission = mission;
         this.assignedDate = assignedDate;
+    }
+
+    public static MissionHistory createMissionHistory(Mission mission, LocalDate assignedDate) {
+        return MissionHistory.builder().mission(mission).assignedDate(assignedDate).build();
     }
 }

--- a/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
@@ -34,16 +34,16 @@ class MissionServiceTest {
     @InjectMocks private MissionService missionService;
 
     private LocalDate today;
-    private LocalDate threeDaysAgo;
+    private LocalDate beforeDayByStandard;
     private Mission mission;
     private MissionHistory missionHistory;
 
     @BeforeEach
     public void setUp() {
         today = LocalDate.now();
-        threeDaysAgo = LocalDate.now().minusDays(3);
+        beforeDayByStandard = LocalDate.now().minusDays(3);
         mission = Mission.builder().title("Test Mission").build();
-        missionHistory = MissionHistory.builder().mission(mission).assignedDate(today).build();
+        missionHistory = MissionHistory.createMissionHistory(mission, today);
         MockitoAnnotations.openMocks(this);
     }
 
@@ -103,7 +103,8 @@ class MissionServiceTest {
         availableMissions.add(Mission.builder().title("4일 전 미션").build());
         availableMissions.add(Mission.builder().title("5일 전 미션").build());
 
-        when(missionRepository.findMissionsAssignedBefore(threeDaysAgo)).thenReturn(recentMissions);
+        when(missionRepository.findMissionsAssignedAfter(beforeDayByStandard))
+                .thenReturn(recentMissions);
 
         when(missionRepository.findNotInMissions(recentMissions)).thenReturn(availableMissions);
 
@@ -123,7 +124,7 @@ class MissionServiceTest {
         // Given: 초기 설정
         List<Mission> emptyMissionList = new ArrayList<>();
 
-        when(missionRepository.findMissionsAssignedBefore(today)).thenReturn(emptyMissionList);
+        when(missionRepository.findMissionsAssignedAfter(today)).thenReturn(emptyMissionList);
 
         when(missionRepository.findNotInMissions(emptyMissionList)).thenReturn(emptyMissionList);
 

--- a/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
@@ -33,8 +33,7 @@ class MissionHistoryRepositoryTest {
         missionRepository.save(mission);
         LocalDate today = LocalDate.now();
 
-        MissionHistory missionHistory =
-                MissionHistory.builder().mission(mission).assignedDate(today).build();
+        MissionHistory missionHistory = MissionHistory.createMissionHistory(mission, today);
 
         // When: 미션 히스토리를 저장하면
         MissionHistory savedMissionHistory = missionHistoryRepository.save(missionHistory);
@@ -52,8 +51,7 @@ class MissionHistoryRepositoryTest {
         missionRepository.save(mission);
         LocalDate today = LocalDate.now();
 
-        MissionHistory missionHistory =
-                MissionHistory.builder().mission(mission).assignedDate(today).build();
+        MissionHistory missionHistory = MissionHistory.createMissionHistory(mission, today);
         missionHistoryRepository.save(missionHistory);
 
         // When: 특정 날짜(오늘)의 미션 히스토리를 가져오면


### PR DESCRIPTION
## 🌱 관련 이슈
- close #148 

## 📌 작업 내용
- 오늘의 미션 할당 로직 중 before가 아닌 after로 수정
- `mh1_0.assigned_date> 3일전 LocalDate`로 수정하여 NotIn 처리하도록 수정 

## 🙏 리뷰 요구사항
-

## 📚 레퍼런스
- 
