### PR TITLE
[WALWAL-174] raisepet mission supply

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/mission/api/MissionController.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/api/MissionController.java
@@ -31,19 +31,19 @@ public class MissionController {
     }
 
     @GetMapping("/{missionId}")
-    public MissionGetOneResponse getMission(@PathVariable Long missionId) {
+    public MissionGetOneResponse getMission(@PathVariable("missionId") Long missionId) {
         return missionService.getMission(missionId);
     }
 
     @PatchMapping("/{missionId}")
     public MissionUpdateResponse updateMission(
-            @PathVariable Long missionId,
+            @PathVariable("missionId") Long missionId,
             @Valid @RequestBody MissionUpdateRequest missionUpdateRequest) {
         return missionService.updateMission(missionId, missionUpdateRequest);
     }
 
     @DeleteMapping("/{missionId}")
-    public void deleteMission(@PathVariable Long missionId) {
+    public void deleteMission(@PathVariable("missionId") Long missionId) {
         missionService.deleteMission(missionId);
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
@@ -30,7 +30,11 @@ public class MissionService {
     private static final long MISSION_TODAY_STANDARD = 3;
 
     public MissionCreateResponse createMission(MissionCreateRequest missionCreateRequest) {
-        Mission mission = Mission.builder().title(missionCreateRequest.title()).build();
+        Mission mission =
+                Mission.builder()
+                        .title(missionCreateRequest.title())
+                        .raisePet(missionCreateRequest.raisePet())
+                        .build();
 
         mission = missionRepository.save(mission);
         return MissionCreateResponse.from(mission);
@@ -84,6 +88,7 @@ public class MissionService {
                         .orElseThrow(() -> new CustomException(ErrorCode.MISSION_NOT_FOUND));
 
         missionToUpdate.updateTitle(missionUpdateRequest.title());
+        missionToUpdate.updateRaisePet(missionUpdateRequest.raisePet());
         missionRepository.save(missionToUpdate);
 
         return MissionUpdateResponse.from(missionToUpdate);

--- a/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
@@ -59,7 +59,7 @@ public class MissionService {
         LocalDate beforeDayByStandard = today.minusDays(MISSION_TODAY_STANDARD);
 
         Optional<MissionHistory> existingMissionHistory =
-                missionHistoryRepository.findByAssignedDateAndMission_RaisePet(today, raisePet);
+                missionHistoryRepository.findByAssignedDateAndRaisePet(today, raisePet);
 
         if (existingMissionHistory.isPresent()) {
             return MissionGetTodayResponse.from(existingMissionHistory.get().getMission());

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/mission/MissionRepositoryCustom.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/mission/MissionRepositoryCustom.java
@@ -1,11 +1,12 @@
 package com.depromeet.stonebed.domain.mission.dao.mission;
 
+import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import com.depromeet.stonebed.domain.mission.domain.Mission;
 import java.time.LocalDate;
 import java.util.List;
 
 public interface MissionRepositoryCustom {
-    List<Mission> findNotInMissions(List<Mission> missions);
+    List<Mission> findMissionsAssignedAfterAndByRaisePet(LocalDate assignedDate, RaisePet raisePet);
 
-    List<Mission> findMissionsAssignedAfter(LocalDate assignedDate);
+    List<Mission> findNotInMissionsAndByRaisePet(List<Mission> missions, RaisePet raisePet);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/mission/MissionRepositoryImpl.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/mission/MissionRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.depromeet.stonebed.domain.mission.dao.mission;
 import static com.depromeet.stonebed.domain.mission.domain.QMission.mission;
 import static com.depromeet.stonebed.domain.mission.domain.QMissionHistory.missionHistory;
 
+import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import com.depromeet.stonebed.domain.mission.domain.Mission;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -17,16 +18,21 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Mission> findNotInMissions(List<Mission> missions) {
-        return queryFactory.selectFrom(mission).where(mission.notIn(missions)).fetch();
+    public List<Mission> findNotInMissionsAndByRaisePet(List<Mission> missions, RaisePet raisePet) {
+        return queryFactory
+                .selectFrom(mission)
+                .where(mission.notIn(missions).and(mission.raisePet.eq(raisePet)))
+                .fetch();
     }
 
     @Override
-    public List<Mission> findMissionsAssignedAfter(LocalDate assignedDate) {
+    public List<Mission> findMissionsAssignedAfterAndByRaisePet(
+            LocalDate assignedDate, RaisePet raisePet) {
         return queryFactory
                 .select(missionHistory.mission)
                 .from(missionHistory)
-                .where(assignedDateAfter(assignedDate))
+                .join(missionHistory.mission, mission)
+                .where(assignedDateAfter(assignedDate).and(mission.raisePet.eq(raisePet)))
                 .fetch();
     }
 

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/missionHistory/MissionHistoryRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/missionHistory/MissionHistoryRepository.java
@@ -1,6 +1,5 @@
 package com.depromeet.stonebed.domain.mission.dao.missionHistory;
 
-import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -9,7 +8,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MissionHistoryRepository
         extends JpaRepository<MissionHistory, Long>, MissionHistoryRepositoryCustom {
     Optional<MissionHistory> findByAssignedDate(LocalDate date);
-
-    Optional<MissionHistory> findByAssignedDateAndMission_RaisePet(
-            LocalDate date, RaisePet raisePet);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/missionHistory/MissionHistoryRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/missionHistory/MissionHistoryRepository.java
@@ -1,8 +1,8 @@
 package com.depromeet.stonebed.domain.mission.dao.missionHistory;
 
+import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,5 +10,6 @@ public interface MissionHistoryRepository
         extends JpaRepository<MissionHistory, Long>, MissionHistoryRepositoryCustom {
     Optional<MissionHistory> findByAssignedDate(LocalDate date);
 
-    List<MissionHistory> findByAssignedDateBefore(LocalDate date);
+    Optional<MissionHistory> findByAssignedDateAndMission_RaisePet(
+            LocalDate date, RaisePet raisePet);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/missionHistory/MissionHistoryRepositoryCustom.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/missionHistory/MissionHistoryRepositoryCustom.java
@@ -1,8 +1,12 @@
 package com.depromeet.stonebed.domain.mission.dao.missionHistory;
 
+import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface MissionHistoryRepositoryCustom {
     Optional<MissionHistory> findLatestOneByMissionId(Long missionId);
+
+    Optional<MissionHistory> findByAssignedDateAndRaisePet(LocalDate date, RaisePet raisePet);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dao/missionHistory/MissionHistoryRepositoryImpl.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dao/missionHistory/MissionHistoryRepositoryImpl.java
@@ -2,8 +2,10 @@ package com.depromeet.stonebed.domain.mission.dao.missionHistory;
 
 import static com.depromeet.stonebed.domain.mission.domain.QMissionHistory.missionHistory;
 
+import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -20,6 +22,20 @@ public class MissionHistoryRepositoryImpl implements MissionHistoryRepositoryCus
                         .selectFrom(missionHistory)
                         .where(missionHistory.mission.id.eq(missionId))
                         .orderBy(missionHistory.assignedDate.desc())
+                        .fetchFirst());
+    }
+
+    @Override
+    public Optional<MissionHistory> findByAssignedDateAndRaisePet(
+            LocalDate date, RaisePet raisePet) {
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(missionHistory)
+                        .where(
+                                missionHistory
+                                        .assignedDate
+                                        .eq(date)
+                                        .and(missionHistory.mission.raisePet.eq(raisePet)))
                         .fetchFirst());
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/mission/domain/Mission.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/domain/Mission.java
@@ -1,8 +1,11 @@
 package com.depromeet.stonebed.domain.mission.domain;
 
 import com.depromeet.stonebed.domain.common.BaseTimeEntity;
+import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,9 +30,14 @@ public class Mission extends BaseTimeEntity {
     @Column(name = "illustration_url")
     private String illustrationUrl;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "raise_pet", nullable = false)
+    private RaisePet raisePet;
+
     @Builder
-    public Mission(String title) {
+    public Mission(String title, RaisePet raisePet) {
         this.title = title;
+        this.raisePet = raisePet;
     }
 
     public void updateTitle(String title) {
@@ -38,5 +46,9 @@ public class Mission extends BaseTimeEntity {
 
     public void updateIllustrationUrl(String illustrationUrl) {
         this.illustrationUrl = illustrationUrl;
+    }
+
+    public void updateRaisePet(RaisePet raisePet) {
+        this.raisePet = raisePet;
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/mission/domain/MissionHistory.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/domain/MissionHistory.java
@@ -11,6 +11,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "mission_history",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"assigned_date", "mission_id"})})
 public class MissionHistory extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,7 +24,7 @@ public class MissionHistory extends BaseTimeEntity {
     @JoinColumn(name = "mission_id", nullable = false)
     private Mission mission;
 
-    @Column(name = "assigned_date", nullable = false, unique = true)
+    @Column(name = "assigned_date", nullable = false)
     private LocalDate assignedDate;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dto/request/MissionCreateRequest.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dto/request/MissionCreateRequest.java
@@ -1,9 +1,14 @@
 package com.depromeet.stonebed.domain.mission.dto.request;
 
+import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record MissionCreateRequest(
         @Schema(description = "미션 제목", example = "산책하기")
                 @NotBlank(message = "Title cannot be blank")
-                String title) {}
+                String title,
+        @Schema(description = "반려동물 유형", example = "DOG")
+                @NotNull(message = "RaisePet cannot be null")
+                RaisePet raisePet) {}

--- a/src/main/java/com/depromeet/stonebed/domain/mission/dto/request/MissionUpdateRequest.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/dto/request/MissionUpdateRequest.java
@@ -1,9 +1,14 @@
 package com.depromeet.stonebed.domain.mission.dto.request;
 
+import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record MissionUpdateRequest(
         @Schema(description = "미션 제목", example = "산책하기")
                 @NotBlank(message = "Title cannot be blank")
-                String title) {}
+                String title,
+        @Schema(description = "반려동물 유형", example = "DOG")
+                @NotNull(message = "RaisePet cannot be null")
+                RaisePet raisePet) {}

--- a/src/test/java/com/depromeet/stonebed/domain/mission/api/MissionControllerTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/api/MissionControllerTest.java
@@ -53,7 +53,7 @@ class MissionControllerTest {
         mockMvc.perform(
                         post("/missions")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content("{\"title\":\"Test Mission\"}"))
+                                .content("{\"title\":\"Test Mission\", \"raisePet\":\"DOG\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.title").value("Test Mission"));
     }
@@ -93,7 +93,7 @@ class MissionControllerTest {
         mockMvc.perform(
                         patch("/missions/1")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content("{\"title\":\"Updated Mission\"}"))
+                                .content("{\"title\":\"Test Mission\", \"raisePet\":\"DOG\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.title").value("Updated Mission"));
     }

--- a/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
@@ -1,7 +1,7 @@
 package com.depromeet.stonebed.domain.mission.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.depromeet.stonebed.domain.member.domain.Member;
@@ -47,7 +47,7 @@ class MissionServiceTest {
     public void setUp() {
         today = LocalDate.now();
         beforeDayByStandard = LocalDate.now().minusDays(3);
-        mission = Mission.builder().title("Test Mission").build();
+        mission = Mission.builder().title("Test Mission").raisePet(RaisePet.DOG).build();
         missionHistory = MissionHistory.createMissionHistory(mission, today);
         member = mock(Member.class);
         MockitoAnnotations.openMocks(this);
@@ -80,6 +80,7 @@ class MissionServiceTest {
         // Then
         assertThat(missionGetOneResponse.title()).isEqualTo("Test Mission");
         verify(missionRepository, times(1)).findById(anyLong());
+        assertEquals(RaisePet.DOG, mission.getRaisePet());
     }
 
     @Test
@@ -89,7 +90,7 @@ class MissionServiceTest {
         Mission mission = new Mission("Test Mission", RaisePet.DOG);
         MissionHistory missionHistory = MissionHistory.createMissionHistory(mission, today);
 
-        when(missionHistoryRepository.findByAssignedDateAndMission_RaisePet(today, RaisePet.DOG))
+        when(missionHistoryRepository.findByAssignedDateAndRaisePet(today, RaisePet.DOG))
                 .thenReturn(Optional.of(missionHistory));
         when(memberUtil.getCurrentMember()).thenReturn(member);
         when(member.getRaisePet()).thenReturn(RaisePet.DOG);
@@ -101,8 +102,9 @@ class MissionServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.title()).isEqualTo("Test Mission");
         verify(missionHistoryRepository, times(1))
-                .findByAssignedDateAndMission_RaisePet(today, RaisePet.DOG);
+                .findByAssignedDateAndRaisePet(today, RaisePet.DOG);
         verify(missionHistoryRepository, times(0)).save(any(MissionHistory.class));
+        assertEquals(RaisePet.DOG, mission.getRaisePet());
     }
 
     @Test
@@ -136,6 +138,7 @@ class MissionServiceTest {
         // Then: 각 메서드들이 실행됐는지 검증
         assertThat(result).isNotNull();
         assertThat(result.title()).isIn("4일 전 미션", "5일 전 미션");
+        assertEquals(RaisePet.DOG, member.getRaisePet());
     }
 
     @Test
@@ -180,12 +183,14 @@ class MissionServiceTest {
         when(missionRepository.findById(anyLong())).thenReturn(Optional.of(mission));
 
         // When
+        MissionUpdateRequest updateRequest =
+                new MissionUpdateRequest("Updated Mission", RaisePet.DOG);
         MissionUpdateResponse missionUpdateResponse =
-                missionService.updateMission(
-                        1L, new MissionUpdateRequest("Updated Mission", RaisePet.DOG));
+                missionService.updateMission(1L, updateRequest);
 
         // Then
         assertThat(missionUpdateResponse.title()).isEqualTo("Updated Mission");
+        assertEquals(RaisePet.DOG, mission.getRaisePet()); // RaisePet 검증 추가
         verify(missionRepository, times(1)).findById(anyLong());
         verify(missionRepository, times(1)).save(any(Mission.class));
     }

--- a/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
@@ -86,12 +86,13 @@ class MissionServiceTest {
     @Test
     void 오늘의_미션_조회_성공_히스토리가_이미_존재하는_경우() {
         // Given
-        LocalDate today = LocalDate.now();
-        Mission mission = new Mission("Test Mission", RaisePet.DOG);
-        MissionHistory missionHistory = MissionHistory.createMissionHistory(mission, today);
+        LocalDate currentDate = LocalDate.now();
+        Mission localMission = new Mission("Test Mission", RaisePet.DOG);
+        MissionHistory localMissionHistory =
+                MissionHistory.createMissionHistory(localMission, currentDate);
 
-        when(missionHistoryRepository.findByAssignedDateAndRaisePet(today, RaisePet.DOG))
-                .thenReturn(Optional.of(missionHistory));
+        when(missionHistoryRepository.findByAssignedDateAndRaisePet(currentDate, RaisePet.DOG))
+                .thenReturn(Optional.of(localMissionHistory));
         when(memberUtil.getCurrentMember()).thenReturn(member);
         when(member.getRaisePet()).thenReturn(RaisePet.DOG);
 

--- a/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
@@ -3,6 +3,7 @@ package com.depromeet.stonebed.domain.mission.dao;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.depromeet.stonebed.TestQuerydslConfig;
+import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import com.depromeet.stonebed.domain.mission.dao.mission.MissionRepository;
 import com.depromeet.stonebed.domain.mission.dao.missionHistory.MissionHistoryRepository;
 import com.depromeet.stonebed.domain.mission.domain.Mission;
@@ -29,7 +30,7 @@ class MissionHistoryRepositoryTest {
     @Test
     void 미션_히스토리_생성_성공() {
         // Given: 오늘 날짜를 기준으로 미션 히스토리가 있다 (생성할 예정)
-        Mission mission = Mission.builder().title("Test Mission").build();
+        Mission mission = Mission.builder().title("Test Mission").raisePet(RaisePet.DOG).build();
         missionRepository.save(mission);
         LocalDate today = LocalDate.now();
 
@@ -47,7 +48,7 @@ class MissionHistoryRepositoryTest {
     @Test
     void 미션_히스토리_특정_날짜_조회_성공() {
         // Given: 오늘 날짜를 기준으로 저장된 객체가 있다
-        Mission mission = Mission.builder().title("Test Mission").build();
+        Mission mission = Mission.builder().title("Test Mission").raisePet(RaisePet.DOG).build();
         missionRepository.save(mission);
         LocalDate today = LocalDate.now();
 

--- a/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionRepositoryTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionRepositoryTest.java
@@ -3,6 +3,7 @@ package com.depromeet.stonebed.domain.mission.dao;
 import static org.assertj.core.api.Assertions.*;
 
 import com.depromeet.stonebed.TestQuerydslConfig;
+import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import com.depromeet.stonebed.domain.mission.dao.mission.MissionRepository;
 import com.depromeet.stonebed.domain.mission.domain.Mission;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,7 @@ class MissionRepositoryTest {
     @Test
     void 미션_생성_성공() {
         // Given
-        Mission mission = Mission.builder().title("Test Mission").build();
+        Mission mission = Mission.builder().title("Test Mission").raisePet(RaisePet.DOG).build();
 
         // When
         Mission savedMission = missionRepository.save(mission);
@@ -34,7 +35,7 @@ class MissionRepositoryTest {
     @Test
     void 고유번호로_미션_조회_성공() {
         // Given
-        Mission mission = Mission.builder().title("Test Mission").build();
+        Mission mission = Mission.builder().title("Test Mission").raisePet(RaisePet.DOG).build();
         missionRepository.save(mission);
 
         // When
@@ -48,7 +49,7 @@ class MissionRepositoryTest {
     @Test
     void 미션_삭제_성공() {
         // Given
-        Mission mission = Mission.builder().title("Test Mission").build();
+        Mission mission = Mission.builder().title("Test Mission").raisePet(RaisePet.DOG).build();
         mission = missionRepository.save(mission);
 
         // When


### PR DESCRIPTION
## 🌱 관련 이슈
- close #167 

## 📌 작업 내용
- 미션별 강아지/고양이 분류
- 본인이 선택한 반려동물에 따라서 /today미션제공
- 하루에 강아지/고양이 1개씩 들어가야하므로 기존 unique값인 assigned_date를 제거하고, assigned_date + mission_id조합으로 uniqueConstraints을 걸어서 관리하도록 했습니다.

## 🙏 리뷰 요구사항
- 제가 요구사항에 맞게 구현한건지 피드백 부탁드립니다!

## 📚 레퍼런스
- 
