### PR TITLE
fix: 회원탈퇴 데이터 초기화

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/auth/application/AuthService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/auth/application/AuthService.java
@@ -129,6 +129,7 @@ public class AuthService {
          */
         validateMemberStatusDelete(member.getStatus());
         member.updateMemberRole(MemberRole.TEMPORARY);
+        member.updateProfile(Profile.createProfile("", ""));
         memberRepository.flush();
 
         jwtTokenService.deleteRefreshToken(member.getId());

--- a/src/main/java/com/depromeet/stonebed/domain/auth/application/AuthService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/auth/application/AuthService.java
@@ -15,7 +15,6 @@ import com.depromeet.stonebed.domain.member.domain.MemberRole;
 import com.depromeet.stonebed.domain.member.domain.MemberStatus;
 import com.depromeet.stonebed.domain.member.domain.Profile;
 import com.depromeet.stonebed.domain.member.dto.request.CreateMemberRequest;
-import com.depromeet.stonebed.domain.member.dto.request.NicknameCheckRequest;
 import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordBoostRepository;
 import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.stonebed.global.error.ErrorCode;
@@ -92,9 +91,6 @@ public class AuthService {
         Member currentMember = memberUtil.getCurrentMember();
         // 사용자 회원가입
         if (memberUtil.getMemberRole().equals(MemberRole.TEMPORARY.getValue())) {
-            // 닉네임 검증
-            memberUtil.checkNickname(NicknameCheckRequest.of(request.nickname()));
-
             // 명시적 변경 감지
             Member registerMember = registerMember(currentMember, request);
 

--- a/src/main/java/com/depromeet/stonebed/domain/auth/application/AuthService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/auth/application/AuthService.java
@@ -137,10 +137,8 @@ public class AuthService {
         member.updateMemberRole(MemberRole.TEMPORARY);
         member.updateProfile(Profile.createProfile("", ""));
         memberRepository.flush();
+        withdrawMemberRelationByMemberId(member.getId());
 
-        missionRecordRepository.deleteAllByMember(member.getId());
-        missionRecordBoostRepository.deleteAllByMember(member.getId());
-        fcmNotificationRepository.deleteAllByMember(member.getId());
         jwtTokenService.deleteRefreshToken(member.getId());
 
         memberRepository.deleteById(member.getId());
@@ -166,5 +164,11 @@ public class AuthService {
         if (member.getStatus() == MemberStatus.DELETED) {
             member.updateStatus(MemberStatus.NORMAL);
         }
+    }
+
+    private void withdrawMemberRelationByMemberId(Long memberId) {
+        missionRecordRepository.deleteAllByMember(memberId);
+        missionRecordBoostRepository.deleteAllByMember(memberId);
+        fcmNotificationRepository.deleteAllByMember(memberId);
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/common/BaseFullTimeEntity.java
+++ b/src/main/java/com/depromeet/stonebed/domain/common/BaseFullTimeEntity.java
@@ -1,0 +1,16 @@
+package com.depromeet.stonebed.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseFullTimeEntity extends BaseTimeEntity {
+    @Column(name = "deleted_at", updatable = false)
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmNotificationRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmNotificationRepository.java
@@ -7,6 +7,9 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FcmNotificationRepository extends JpaRepository<FcmNotification, Long> {
     List<FcmNotification> findByMemberId(Long memberId, Pageable pageable);
@@ -15,4 +18,9 @@ public interface FcmNotificationRepository extends JpaRepository<FcmNotification
             Long memberId, LocalDateTime cursorDate, Pageable pageable);
 
     Optional<FcmNotification> findByIdAndMember(Long id, Member member);
+
+    @Modifying
+    @Query(
+            "UPDATE FcmNotification fn SET fn.deletedAt = CURRENT_TIMESTAMP WHERE fn.member.id = :memberId")
+    void deleteAllByMember(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
@@ -1,17 +1,21 @@
 package com.depromeet.stonebed.domain.fcm.domain;
 
-import com.depromeet.stonebed.domain.common.BaseTimeEntity;
+import com.depromeet.stonebed.domain.common.BaseFullTimeEntity;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
+@Table(name = "fcm_notification")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FcmNotification extends BaseTimeEntity {
-
+@SQLDelete(sql = "UPDATE fcm_notification SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class FcmNotification extends BaseFullTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmToken.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmToken.java
@@ -8,7 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,7 +21,7 @@ public class FcmToken extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 

--- a/src/main/java/com/depromeet/stonebed/domain/member/domain/Member.java
+++ b/src/main/java/com/depromeet/stonebed/domain/member/domain/Member.java
@@ -2,6 +2,11 @@ package com.depromeet.stonebed.domain.member.domain;
 
 import com.depromeet.stonebed.domain.auth.domain.OAuthProvider;
 import com.depromeet.stonebed.domain.common.BaseTimeEntity;
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotification;
+import com.depromeet.stonebed.domain.fcm.domain.FcmToken;
+import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
+import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordBoost;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -10,7 +15,11 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -42,6 +51,18 @@ public class Member extends BaseTimeEntity {
     private RaisePet raisePet;
 
     private LocalDateTime lastLoginAt;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MissionRecord> missionRecords = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MissionRecordBoost> missionRecordBoosts = new ArrayList<>();
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private FcmToken fcmToken;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FcmNotification> fcmNotifications = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     public Member(

--- a/src/main/java/com/depromeet/stonebed/domain/member/domain/Member.java
+++ b/src/main/java/com/depromeet/stonebed/domain/member/domain/Member.java
@@ -25,11 +25,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member SET status = 'DELETED' WHERE member_id = ?")
+@SQLRestriction("status != 'DELETED'")
 public class Member extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/depromeet/stonebed/domain/member/domain/Member.java
+++ b/src/main/java/com/depromeet/stonebed/domain/member/domain/Member.java
@@ -3,7 +3,6 @@ package com.depromeet.stonebed.domain.member.domain;
 import com.depromeet.stonebed.domain.auth.domain.OAuthProvider;
 import com.depromeet.stonebed.domain.common.BaseTimeEntity;
 import com.depromeet.stonebed.domain.fcm.domain.FcmNotification;
-import com.depromeet.stonebed.domain.fcm.domain.FcmToken;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordBoost;
 import jakarta.persistence.CascadeType;
@@ -16,7 +15,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,9 +57,6 @@ public class Member extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MissionRecordBoost> missionRecordBoosts = new ArrayList<>();
-
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private FcmToken fcmToken;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FcmNotification> fcmNotifications = new ArrayList<>();

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordBoostRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordBoostRepository.java
@@ -2,6 +2,7 @@ package com.depromeet.stonebed.domain.missionRecord.dao;
 
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordBoost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -9,4 +10,9 @@ public interface MissionRecordBoostRepository extends JpaRepository<MissionRecor
     @Query(
             "SELECT SUM(mrb.count) FROM MissionRecordBoost mrb WHERE mrb.missionRecord.id = :missionRecordId")
     Long sumBoostCountByMissionRecord(@Param("missionRecordId") Long missionRecordId);
+
+    @Modifying
+    @Query(
+            "UPDATE MissionRecordBoost mrb SET mrb.deletedAt = CURRENT_TIMESTAMP WHERE mrb.member.id = :memberId")
+    void deleteAllByMember(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepository.java
@@ -7,6 +7,9 @@ import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MissionRecordRepository
         extends JpaRepository<MissionRecord, Long>, MissionRecordRepositoryCustom {
@@ -18,4 +21,9 @@ public interface MissionRecordRepository
     List<MissionRecord> findAllByStatus(MissionRecordStatus status);
 
     List<MissionRecord> findByIdIn(List<Long> ids);
+
+    @Modifying
+    @Query(
+            "UPDATE MissionRecord mr SET mr.deletedAt = CURRENT_TIMESTAMP WHERE mr.member.id = :memberId")
+    void deleteAllByMember(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecord.java
@@ -31,11 +31,11 @@ public class MissionRecord extends BaseFullTimeEntity {
     @Column(name = "record_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_history_id", nullable = false)
     private MissionHistory missionHistory;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecord.java
@@ -1,6 +1,6 @@
 package com.depromeet.stonebed.domain.missionRecord.domain;
 
-import com.depromeet.stonebed.domain.common.BaseTimeEntity;
+import com.depromeet.stonebed.domain.common.BaseFullTimeEntity;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.domain.mission.domain.MissionHistory;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,6 +9,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
@@ -20,7 +22,9 @@ import lombok.NoArgsConstructor;
                     name = "uk_member_mission_history",
                     columnNames = {"member_id", "mission_history_id"})
         })
-public class MissionRecord extends BaseTimeEntity {
+@SQLDelete(sql = "UPDATE mission_record SET deleted_at = NOW() WHERE record_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class MissionRecord extends BaseFullTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,7 +48,7 @@ public class MissionRecord extends BaseTimeEntity {
     private MissionRecordStatus status;
 
     @Schema(description = "미션 기록 컨텐츠", example = "미션 완료 소감")
-    @Column(name = "content", nullable = true)
+    @Column(name = "content")
     private String content;
 
     @Builder

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecordBoost.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecordBoost.java
@@ -21,7 +21,7 @@ public class MissionRecordBoost {
     private MissionRecord missionRecord;
 
     @ManyToOne
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @Column(name = "count", nullable = false)

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecordBoost.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecordBoost.java
@@ -1,16 +1,22 @@
 package com.depromeet.stonebed.domain.missionRecord.domain;
 
+import com.depromeet.stonebed.domain.common.BaseFullTimeEntity;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
+@Table(name = "mission_record_boost")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MissionRecordBoost {
+@SQLDelete(sql = "UPDATE mission_record_boost SET deleted_at = NOW() WHERE boost_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class MissionRecordBoost extends BaseFullTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "boost_id")

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecordBoost.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecordBoost.java
@@ -22,11 +22,11 @@ public class MissionRecordBoost extends BaseFullTimeEntity {
     @Column(name = "boost_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_record_id", nullable = false)
     private MissionRecord missionRecord;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/depromeet/stonebed/global/util/MemberUtil.java
+++ b/src/main/java/com/depromeet/stonebed/global/util/MemberUtil.java
@@ -7,6 +7,7 @@ import com.depromeet.stonebed.global.error.ErrorCode;
 import com.depromeet.stonebed.global.error.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -15,12 +16,14 @@ public class MemberUtil {
     private final SecurityUtil securityUtil;
     private final MemberRepository memberRepository;
 
+    @Transactional(readOnly = true)
     public Member getCurrentMember() {
         return memberRepository
                 .findById(securityUtil.getCurrentMemberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
     public Member getMemberByMemberId(Long memberId) {
         return memberRepository
                 .findById(memberId)
@@ -35,6 +38,7 @@ public class MemberUtil {
         return role;
     }
 
+    @Transactional(readOnly = true)
     public void checkNickname(NicknameCheckRequest request) {
         validateNicknameNotDuplicate(request.nickname());
         if (validateNicknameText(request.nickname())) {

--- a/src/test/java/com/depromeet/stonebed/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/auth/application/AuthServiceTest.java
@@ -131,7 +131,6 @@ class AuthServiceTest extends FixtureMonkeySetUp {
         authService.withdraw();
 
         // then
-        // 플러시가 호출되었는지 확인
         verify(memberRepository).flush();
 
         // 실제 삭제가 이뤄졌는지 확인

--- a/src/test/java/com/depromeet/stonebed/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/auth/application/AuthServiceTest.java
@@ -118,6 +118,15 @@ class AuthServiceTest extends FixtureMonkeySetUp {
                         .sample();
         when(memberUtil.getCurrentMember()).thenReturn(member);
 
+        // Mocking: deleteById가 호출될 때 MemberStatus를 DELETED로 변경
+        doAnswer(
+                        invocation -> {
+                            member.updateStatus(MemberStatus.DELETED);
+                            return null;
+                        })
+                .when(memberRepository)
+                .deleteById(member.getId());
+
         // when
         authService.withdraw();
 
@@ -125,12 +134,17 @@ class AuthServiceTest extends FixtureMonkeySetUp {
         // 플러시가 호출되었는지 확인
         verify(memberRepository).flush();
 
-        // @SQLDelete가 적용된 이후의 상태를 확인하기 위해, 실제 삭제가 이뤄졌는지 확인
+        // 실제 삭제가 이뤄졌는지 확인
         verify(memberRepository).deleteById(member.getId());
         assertEquals(MemberRole.TEMPORARY, member.getRole());
+        assertEquals("", member.getProfile().getProfileImageUrl());
+        assertEquals("", member.getProfile().getNickname());
 
         // jwtTokenService에서 리프레시 토큰 삭제가 호출되었는지 확인
         verify(jwtTokenService).deleteRefreshToken(member.getId());
+
+        // MemberStatus가 DELETED로 변경되었는지 확인
+        assertEquals(MemberStatus.DELETED, member.getStatus());
     }
 
     private void assertCommonAssertions(

--- a/src/test/java/com/depromeet/stonebed/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/auth/application/AuthServiceTest.java
@@ -7,10 +7,13 @@ import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.auth.domain.OAuthProvider;
 import com.depromeet.stonebed.domain.auth.dto.response.AuthTokenResponse;
 import com.depromeet.stonebed.domain.auth.dto.response.TokenPairResponse;
+import com.depromeet.stonebed.domain.fcm.dao.FcmNotificationRepository;
 import com.depromeet.stonebed.domain.member.dao.MemberRepository;
 import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.domain.member.domain.MemberRole;
 import com.depromeet.stonebed.domain.member.domain.MemberStatus;
+import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordBoostRepository;
+import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.stonebed.global.util.MemberUtil;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +33,10 @@ class AuthServiceTest extends FixtureMonkeySetUp {
     @Mock private JwtTokenService jwtTokenService;
 
     @Mock private MemberRepository memberRepository;
+
+    @Mock private FcmNotificationRepository fcmNotificationRepository;
+    @Mock private MissionRecordRepository missionRecordRepository;
+    @Mock private MissionRecordBoostRepository missionRecordBoostRepository;
 
     @Mock private MemberUtil memberUtil;
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #164 

## 📌 작업 내용
- 회원 탈퇴 시 deleteById로 delete 이벤트 발생 시 cascade에 따른 데이터 삭제
  - cascade 삭제를 시도했으나 row마다 쿼리가 발생되는 이슈로 native 쿼리 방식 활용
  - soft-delete 처리 시 언제 삭제를 진행했는지 트래킹 활용 목적으로 deletedAt을 추가
- Profile 데이터 초기화
- 테스트 코드 수정

## 🙏 리뷰 요구사항
- 잠수함 패치로 MemberUtil 코드 Transactional 어노테이션 추가
- boost엔티티 member 정보 null 허용
- Lazy 로딩 추가

## 📚 레퍼런스
- 
