### PR TITLE
fix: today 미션 raisePet에 따라 미션 할당

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/application/MissionService.java
@@ -81,7 +81,8 @@ public class MissionService {
         Mission selectedMission =
                 availableMissions.get(secureRandom.nextInt(availableMissions.size()));
 
-        MissionHistory missionHistory = MissionHistory.createMissionHistory(selectedMission, today);
+        MissionHistory missionHistory =
+                MissionHistory.createMissionHistory(selectedMission, today, raisePet);
 
         missionHistoryRepository.save(missionHistory);
 

--- a/src/main/java/com/depromeet/stonebed/domain/mission/domain/MissionHistory.java
+++ b/src/main/java/com/depromeet/stonebed/domain/mission/domain/MissionHistory.java
@@ -1,6 +1,7 @@
 package com.depromeet.stonebed.domain.mission.domain;
 
 import com.depromeet.stonebed.domain.common.BaseTimeEntity;
+import com.depromeet.stonebed.domain.member.domain.RaisePet;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import lombok.AccessLevel;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
         name = "mission_history",
-        uniqueConstraints = {@UniqueConstraint(columnNames = {"assigned_date", "mission_id"})})
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"assigned_date", "raise_pet"})})
 public class MissionHistory extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,13 +28,23 @@ public class MissionHistory extends BaseTimeEntity {
     @Column(name = "assigned_date", nullable = false)
     private LocalDate assignedDate;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "raise_pet", nullable = false)
+    private RaisePet raisePet;
+
     @Builder(access = AccessLevel.PRIVATE)
-    public MissionHistory(Mission mission, LocalDate assignedDate) {
+    public MissionHistory(Mission mission, LocalDate assignedDate, RaisePet raisePet) {
         this.mission = mission;
         this.assignedDate = assignedDate;
+        this.raisePet = raisePet;
     }
 
-    public static MissionHistory createMissionHistory(Mission mission, LocalDate assignedDate) {
-        return MissionHistory.builder().mission(mission).assignedDate(assignedDate).build();
+    public static MissionHistory createMissionHistory(
+            Mission mission, LocalDate assignedDate, RaisePet raisePet) {
+        return MissionHistory.builder()
+                .mission(mission)
+                .assignedDate(assignedDate)
+                .raisePet(raisePet)
+                .build();
     }
 }

--- a/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/application/MissionServiceTest.java
@@ -48,7 +48,7 @@ class MissionServiceTest {
         today = LocalDate.now();
         beforeDayByStandard = LocalDate.now().minusDays(3);
         mission = Mission.builder().title("Test Mission").raisePet(RaisePet.DOG).build();
-        missionHistory = MissionHistory.createMissionHistory(mission, today);
+        missionHistory = MissionHistory.createMissionHistory(mission, today, RaisePet.DOG);
         member = mock(Member.class);
         MockitoAnnotations.openMocks(this);
     }
@@ -89,7 +89,7 @@ class MissionServiceTest {
         LocalDate currentDate = LocalDate.now();
         Mission localMission = new Mission("Test Mission", RaisePet.DOG);
         MissionHistory localMissionHistory =
-                MissionHistory.createMissionHistory(localMission, currentDate);
+                MissionHistory.createMissionHistory(localMission, currentDate, RaisePet.DOG);
 
         when(missionHistoryRepository.findByAssignedDateAndRaisePet(currentDate, RaisePet.DOG))
                 .thenReturn(Optional.of(localMissionHistory));

--- a/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/mission/dao/MissionHistoryRepositoryTest.java
@@ -34,7 +34,8 @@ class MissionHistoryRepositoryTest {
         missionRepository.save(mission);
         LocalDate today = LocalDate.now();
 
-        MissionHistory missionHistory = MissionHistory.createMissionHistory(mission, today);
+        MissionHistory missionHistory =
+                MissionHistory.createMissionHistory(mission, today, RaisePet.DOG);
 
         // When: 미션 히스토리를 저장하면
         MissionHistory savedMissionHistory = missionHistoryRepository.save(missionHistory);
@@ -48,11 +49,12 @@ class MissionHistoryRepositoryTest {
     @Test
     void 미션_히스토리_특정_날짜_조회_성공() {
         // Given: 오늘 날짜를 기준으로 저장된 객체가 있다
-        Mission mission = Mission.builder().title("Test Mission").raisePet(RaisePet.DOG).build();
+        Mission mission = Mission.builder().title("Test Mission").raisePet(RaisePet.CAT).build();
         missionRepository.save(mission);
         LocalDate today = LocalDate.now();
 
-        MissionHistory missionHistory = MissionHistory.createMissionHistory(mission, today);
+        MissionHistory missionHistory =
+                MissionHistory.createMissionHistory(mission, today, RaisePet.CAT);
         missionHistoryRepository.save(missionHistory);
 
         // When: 특정 날짜(오늘)의 미션 히스토리를 가져오면


### PR DESCRIPTION
## 🌱 관련 이슈
- close #175 

## 📌 작업 내용
- missionHistory에 raisePet 값 추가
- unique 제약 조건을 missionId -> raisePet으로 변경

## 🙏 리뷰 요구사항
-

## 📚 레퍼런스
- 
