### PR TITLE
fix: 피드 nextCursor=null 처리 및 미션기록 상태 완료만 나오도록 처리 & 멤버 파라메터 추가

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/feed/api/FeedController.java
+++ b/src/main/java/com/depromeet/stonebed/domain/feed/api/FeedController.java
@@ -18,8 +18,10 @@ public class FeedController {
     @Operation(summary = "피드 조회", description = "내 피드를 조회하는 API입니다.")
     @GetMapping
     public FeedGetResponse getFeed(
-            @RequestParam(required = false) String cursor, @RequestParam int limit) {
-        FeedGetRequest request = new FeedGetRequest(cursor, limit);
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) Long memberId,
+            @RequestParam int limit) {
+        FeedGetRequest request = new FeedGetRequest(cursor, memberId, limit);
         return feedService.getFeed(request);
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/feed/application/FeedService.java
@@ -44,7 +44,7 @@ public class FeedService {
     }
 
     private String getNextCursor(List<FindFeedDto> records, int limit) {
-        if (records.size() <= limit) {
+        if (records.size() < limit) {
             return null;
         }
 

--- a/src/main/java/com/depromeet/stonebed/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/feed/application/FeedService.java
@@ -35,12 +35,12 @@ public class FeedService {
     }
 
     private boolean nextFeedNotExists(List<FindFeedDto> feeds, Long memberId) {
-        Long lastFeedId = getLastId(feeds);
-        if (lastFeedId == null) {
+        Long lastRecordId = getLastRecordId(feeds);
+        if (lastRecordId == null) {
             return true;
         }
 
-        return feedRepository.getNextFeedContent(lastFeedId, memberId) == null;
+        return feedRepository.getNextFeedContent(lastRecordId, memberId) == null;
     }
 
     private String getNextCursor(List<FindFeedDto> records, int limit) {
@@ -48,10 +48,10 @@ public class FeedService {
             return null;
         }
 
-        return String.valueOf(getLastId(records));
+        return String.valueOf(getLastRecordId(records));
     }
 
-    private Long getLastId(List<FindFeedDto> records) {
+    private Long getLastRecordId(List<FindFeedDto> records) {
         if (records.isEmpty()) {
             return null;
         }

--- a/src/main/java/com/depromeet/stonebed/domain/feed/dao/FeedRepositoryCustom.java
+++ b/src/main/java/com/depromeet/stonebed/domain/feed/dao/FeedRepositoryCustom.java
@@ -6,5 +6,5 @@ import java.util.List;
 public interface FeedRepositoryCustom {
     List<FindFeedDto> getFeedContentsUsingCursor(Long missionRecordId, Long memberId, int limit);
 
-    List<FindFeedDto> getFeedContents(Long memberId, int limit);
+    FindFeedDto getNextFeedContent(Long missionRecordId, Long memberId);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/feed/dto/request/FeedGetRequest.java
+++ b/src/main/java/com/depromeet/stonebed/domain/feed/dto/request/FeedGetRequest.java
@@ -4,4 +4,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record FeedGetRequest(
         @Schema(description = "커서 위치", example = "1") String cursor,
+        @Schema(description = "작성자 ID", example = "1") Long memberId,
         @Schema(description = "피드 당 항목 수", example = "5") int limit) {}

--- a/src/test/java/com/depromeet/stonebed/domain/feed/application/FeedServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/feed/application/FeedServiceTest.java
@@ -26,6 +26,10 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class FeedServiceTest extends FixtureMonkeySetUp {
+    int DEFAULT_LIMIT = 5;
+    Long DEFAULT_TOTAL_BOOST_COUNT = 100L;
+    String DEFAULT_CURSOR = "5";
+    String INVALID_CURSOR = "2024-08-01";
 
     @InjectMocks private FeedService feedService;
 
@@ -42,16 +46,18 @@ class FeedServiceTest extends FixtureMonkeySetUp {
                             fixtureMonkey.giveMeOne(Mission.class),
                             fixtureMonkey.giveMeOne(MissionRecord.class),
                             fixtureMonkey.giveMeOne(Member.class),
-                            100L));
+                            DEFAULT_TOTAL_BOOST_COUNT));
         }
 
-        when(feedRepository.getFeedContentsUsingCursor(null, null, 5)).thenReturn(feeds);
+        when(feedRepository.getFeedContentsUsingCursor(null, null, DEFAULT_LIMIT))
+                .thenReturn(feeds);
         when(feedRepository.getNextFeedContent(
                         feeds.get(feeds.size() - 1).missionRecord().getId(), null))
                 .thenReturn(null);
 
         // When
-        FeedGetResponse feedGetResponse = feedService.getFeed(new FeedGetRequest(null, null, 5));
+        FeedGetResponse feedGetResponse =
+                feedService.getFeed(new FeedGetRequest(null, null, DEFAULT_LIMIT));
 
         // Then
         assertThat(feedGetResponse.list().size()).isEqualTo(5);
@@ -62,7 +68,6 @@ class FeedServiceTest extends FixtureMonkeySetUp {
     void 피드_조회_커서_사용_성공() {
         // Given
         List<FindFeedDto> feeds = new ArrayList<>();
-        String cursor = "3";
 
         for (int i = 0; i < 5; i++) {
             feeds.add(
@@ -70,28 +75,38 @@ class FeedServiceTest extends FixtureMonkeySetUp {
                             fixtureMonkey.giveMeOne(Mission.class),
                             fixtureMonkey.giveMeOne(MissionRecord.class),
                             fixtureMonkey.giveMeOne(Member.class),
-                            100L));
+                            DEFAULT_TOTAL_BOOST_COUNT));
         }
 
-        when(feedRepository.getFeedContentsUsingCursor(Long.parseLong(cursor), null, 5))
+        when(feedRepository.getFeedContentsUsingCursor(
+                        Long.parseLong(DEFAULT_CURSOR), null, DEFAULT_LIMIT))
                 .thenReturn(feeds);
+
+        FindFeedDto nextFeed =
+                FindFeedDto.from(
+                        fixtureMonkey.giveMeOne(Mission.class),
+                        fixtureMonkey.giveMeOne(MissionRecord.class),
+                        fixtureMonkey.giveMeOne(Member.class),
+                        DEFAULT_TOTAL_BOOST_COUNT);
+
         when(feedRepository.getNextFeedContent(
                         feeds.get(feeds.size() - 1).missionRecord().getId(), null))
-                .thenReturn(null);
+                .thenReturn(nextFeed);
 
         // When
-        FeedGetResponse feedGetResponse = feedService.getFeed(new FeedGetRequest(cursor, null, 5));
+        FeedGetResponse feedGetResponse =
+                feedService.getFeed(new FeedGetRequest(DEFAULT_CURSOR, null, DEFAULT_LIMIT));
 
         // Then
         assertThat(feedGetResponse.list().size()).isEqualTo(5);
-        assertThat(feedGetResponse.nextCursor()).isEqualTo(null);
+        assertThat(feedGetResponse.nextCursor())
+                .isEqualTo(String.valueOf(feeds.get(feeds.size() - 1).missionRecord().getId()));
     }
 
     @Test
     void 피드_조회_커서_사용_마지막_성공() {
         // Given
         List<FindFeedDto> feeds = new ArrayList<>();
-        String cursor = "5";
 
         for (int i = 0; i < 3; i++) {
             feeds.add(
@@ -99,24 +114,19 @@ class FeedServiceTest extends FixtureMonkeySetUp {
                             fixtureMonkey.giveMeOne(Mission.class),
                             fixtureMonkey.giveMeOne(MissionRecord.class),
                             fixtureMonkey.giveMeOne(Member.class),
-                            100L));
+                            DEFAULT_TOTAL_BOOST_COUNT));
         }
 
-        FindFeedDto nextFeed =
-                FindFeedDto.from(
-                        fixtureMonkey.giveMeOne(Mission.class),
-                        fixtureMonkey.giveMeOne(MissionRecord.class),
-                        fixtureMonkey.giveMeOne(Member.class),
-                        100L);
-
-        when(feedRepository.getFeedContentsUsingCursor(Long.parseLong(cursor), null, 5))
+        when(feedRepository.getFeedContentsUsingCursor(
+                        Long.parseLong(DEFAULT_CURSOR), null, DEFAULT_LIMIT))
                 .thenReturn(feeds);
         when(feedRepository.getNextFeedContent(
                         feeds.get(feeds.size() - 1).missionRecord().getId(), null))
-                .thenReturn(nextFeed);
+                .thenReturn(null);
 
         // When
-        FeedGetResponse feedGetResponse = feedService.getFeed(new FeedGetRequest(cursor, null, 5));
+        FeedGetResponse feedGetResponse =
+                feedService.getFeed(new FeedGetRequest(DEFAULT_CURSOR, null, DEFAULT_LIMIT));
 
         // Then
         assertThat(feedGetResponse.list().size()).isEqualTo(3);
@@ -125,14 +135,13 @@ class FeedServiceTest extends FixtureMonkeySetUp {
 
     @Test
     void 피드_조회_유효하지_않은_커서_실패() {
-        // Given
-        String cursor = "2024-08-01";
-
-        // When
+        // Given & When
         CustomException exception =
                 assertThrows(
                         CustomException.class,
-                        () -> feedService.getFeed(new FeedGetRequest(cursor, null, 5)));
+                        () ->
+                                feedService.getFeed(
+                                        new FeedGetRequest(INVALID_CURSOR, null, DEFAULT_LIMIT)));
 
         // Then: 에러코드 검증
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_CURSOR_FORMAT);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #178 

## 📌 작업 내용
- 피드의 다음 데이터가 없는 경우 nextCursor=null 처리
- 미션기록이 `COMPLETED` 인 데이터만 가져오도록 수정
- 한 멤버만 필터링할 수 있도록 `@RequestParam(required = false) Long memberId` 추가

## 🙏 리뷰 요구사항
-

## 📚 레퍼런스
- 
