### PR TITLE
Fcm 알림 메세지 전송 시 token is not null 조건 추가

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmRepository.java
@@ -7,9 +7,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-public interface FcmRepository extends JpaRepository<FcmToken, Long> {
+public interface FcmRepository extends JpaRepository<FcmToken, Long>, FcmRepositoryCustom {
     Optional<FcmToken> findByMember(Member member);
 
     Optional<FcmToken> findByToken(String token);
@@ -17,9 +16,6 @@ public interface FcmRepository extends JpaRepository<FcmToken, Long> {
     List<FcmToken> findAll();
 
     List<FcmToken> findAllByUpdatedAtBefore(LocalDateTime cutoffDate);
-
-    @Query("SELECT f.token FROM FcmToken f WHERE f.member.status = 'NORMAL'")
-    List<String> findAllValidTokens();
 
     Optional<FcmToken> findByMemberAndMemberStatus(Member member, MemberStatus status);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmRepositoryCustom.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.depromeet.stonebed.domain.fcm.dao;
+
+import java.util.List;
+
+public interface FcmRepositoryCustom {
+    List<String> findAllValidTokens();
+}

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmRepositoryImpl.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.depromeet.stonebed.domain.fcm.dao;
+
+import static com.depromeet.stonebed.domain.fcm.domain.QFcmToken.*;
+import static com.depromeet.stonebed.domain.member.domain.QMember.*;
+
+import com.depromeet.stonebed.domain.member.domain.MemberStatus;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class FcmRepositoryImpl implements FcmRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<String> findAllValidTokens() {
+        return queryFactory
+                .select(fcmToken.token)
+                .from(fcmToken)
+                .join(fcmToken.member, member)
+                .where(member.status.eq(MemberStatus.NORMAL).and(fcmToken.token.isNotNull()))
+                .fetch();
+    }
+}

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmRepositoryImpl.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dao/FcmRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.depromeet.stonebed.domain.fcm.domain.QFcmToken.*;
 import static com.depromeet.stonebed.domain.member.domain.QMember.*;
 
 import com.depromeet.stonebed.domain.member.domain.MemberStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -11,15 +12,23 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FcmRepositoryImpl implements FcmRepositoryCustom {
 
-    private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public List<String> findAllValidTokens() {
-        return queryFactory
+        return jpaQueryFactory
                 .select(fcmToken.token)
                 .from(fcmToken)
                 .join(fcmToken.member, member)
-                .where(member.status.eq(MemberStatus.NORMAL).and(fcmToken.token.isNotNull()))
+                .where(isMemberStatusNormal(), isTokenNotNull())
                 .fetch();
+    }
+
+    private BooleanExpression isMemberStatusNormal() {
+        return member.status.eq(MemberStatus.NORMAL);
+    }
+
+    private BooleanExpression isTokenNotNull() {
+        return fcmToken.token.isNotNull();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #192 

## 📌 작업 내용
- 기존 JPQL쿼리에서 확장성을 생각해 QueryDSL로 바꿨고, 조건에 token is not null 추가

## 🙏 리뷰 요구사항
-

## 📚 레퍼런스
- 
