### PR TITLE
미션 기록 캘린더 중복 로직 수정

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/api/MissionRecordController.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/api/MissionRecordController.java
@@ -2,6 +2,7 @@ package com.depromeet.stonebed.domain.missionRecord.api;
 
 import com.depromeet.stonebed.domain.missionRecord.application.MissionRecordService;
 import com.depromeet.stonebed.domain.missionRecord.dto.request.MissionRecordBoostRequest;
+import com.depromeet.stonebed.domain.missionRecord.dto.request.MissionRecordCalendarRequest;
 import com.depromeet.stonebed.domain.missionRecord.dto.request.MissionRecordSaveRequest;
 import com.depromeet.stonebed.domain.missionRecord.dto.request.MissionRecordStartRequest;
 import com.depromeet.stonebed.domain.missionRecord.dto.response.MissionRecordCalendarResponse;
@@ -12,8 +13,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -57,22 +56,9 @@ public class MissionRecordController {
     @Operation(summary = "캘린더 형식의 미션 기록 조회", description = "회원의 미션 기록을 페이징하여 조회한다.")
     @GetMapping("/calendar")
     public MissionRecordCalendarResponse getMissionRecordsForCalendar(
-            @Parameter(description = "커서 위치", example = "2024-01-01")
-                    @Valid
-                    @RequestParam(required = false)
-                    String cursor,
-            @Parameter(description = "페이지 당 항목 수", example = "30")
-                    @Valid
-                    @RequestParam
-                    @NotNull
-                    @Min(1)
-                    int limit,
-            @Parameter(description = "조회할 memberId", example = "1")
-                    @Valid
-                    @RequestParam(required = false)
-                    Long memberId) {
+            @Valid MissionRecordCalendarRequest request) {
 
-        return missionRecordService.getMissionRecordsForCalendar(cursor, limit, memberId);
+        return missionRecordService.getMissionRecordsForCalendar(request);
     }
 
     @Operation(summary = "수행한 총 미션 기록 수", description = "회원이 수행한 총 미션 기록 수를 조회한다.")

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordService.java
@@ -12,6 +12,7 @@ import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordBoost;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordStatus;
+import com.depromeet.stonebed.domain.missionRecord.dto.request.MissionRecordCalendarRequest;
 import com.depromeet.stonebed.domain.missionRecord.dto.response.MissionRecordCalendarDto;
 import com.depromeet.stonebed.domain.missionRecord.dto.response.MissionRecordCalendarResponse;
 import com.depromeet.stonebed.domain.missionRecord.dto.response.MissionRecordCompleteTotal;
@@ -84,6 +85,18 @@ public class MissionRecordService {
         MissionHistory missionHistory =
                 findMissionHistoryByIdAndRaisePet(missionId, mission.getRaisePet());
 
+        LocalDate today = LocalDate.now();
+        boolean recordExists =
+                missionRecordRepository.existsByMemberAndMissionHistoryAndCreatedAtBetween(
+                        member,
+                        missionHistory,
+                        today.atStartOfDay(),
+                        today.plusDays(1).atStartOfDay());
+
+        if (recordExists) {
+            throw new CustomException(ErrorCode.DUPLICATE_MISSION_RECORD);
+        }
+
         MissionRecord missionRecord =
                 missionRecordRepository
                         .findByMemberAndMissionHistory(member, missionHistory)
@@ -130,15 +143,15 @@ public class MissionRecordService {
 
     @Transactional(readOnly = true)
     public MissionRecordCalendarResponse getMissionRecordsForCalendar(
-            String cursor, int limit, Long memberId) {
+            MissionRecordCalendarRequest request) {
         Long findMemberId =
-                Optional.ofNullable(memberId)
+                Optional.ofNullable(request.memberId())
                         .orElseGet(() -> memberUtil.getCurrentMember().getId());
 
-        Pageable pageable = createPageable(limit);
-        List<MissionRecord> records = getMissionRecords(cursor, findMemberId, pageable);
+        Pageable pageable = createPageable(request.limit());
+        List<MissionRecord> records = getMissionRecords(request.cursor(), findMemberId, pageable);
         List<MissionRecordCalendarDto> calendarData = convertToCalendarDto(records);
-        String nextCursor = getNextCursor(records);
+        String nextCursor = getNextCursor(records, request.limit());
 
         return MissionRecordCalendarResponse.from(calendarData, nextCursor);
     }
@@ -167,14 +180,19 @@ public class MissionRecordService {
         }
     }
 
-    private String getNextCursor(List<MissionRecord> records) {
+    private String getNextCursor(List<MissionRecord> records, int limit) {
+        if (records.size() < limit) {
+            return null;
+        }
+        return String.valueOf(getLastRecordId(records));
+    }
+
+    private Long getLastRecordId(List<MissionRecord> records) {
         if (records.isEmpty()) {
             return null;
         }
 
-        MissionRecord lastRecord = records.get(records.size() - 1);
-        LocalDate nextCursorDate = lastRecord.getCreatedAt().toLocalDate().plusDays(1);
-        return nextCursorDate.format(DATE_FORMATTER);
+        return records.get(records.size() - 1).getId();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepository.java
@@ -24,6 +24,12 @@ public interface MissionRecordRepository
 
     List<MissionRecord> findByIdIn(List<Long> ids);
 
+    boolean existsByMemberAndMissionHistoryAndCreatedAtBetween(
+            Member member,
+            MissionHistory missionHistory,
+            LocalDateTime startOfDay,
+            LocalDateTime endOfDay);
+
     @Modifying
     @Query(
             "UPDATE MissionRecord mr SET mr.deletedAt = CURRENT_TIMESTAMP WHERE mr.member.id = :memberId")

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepositoryImpl.java
@@ -34,7 +34,7 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
             Long memberId, LocalDateTime createdAt, Pageable pageable) {
         return queryFactory
                 .selectFrom(missionRecord)
-                .where(missionRecord.member.id.eq(memberId).and(createdAtFrom(createdAt)))
+                .where(isMemberId(memberId).and(createdAtFrom(createdAt)).and(isCompleted()))
                 .orderBy(missionRecord.createdAt.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -61,5 +61,9 @@ public class MissionRecordRepositoryImpl implements MissionRecordRepositoryCusto
 
     private BooleanExpression createdAtFrom(LocalDateTime createdAt) {
         return missionRecord.createdAt.goe(createdAt);
+    }
+
+    private BooleanExpression isCompleted() {
+        return missionRecord.status.eq(MissionRecordStatus.COMPLETED);
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dto/request/MissionRecordCalendarRequest.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dto/request/MissionRecordCalendarRequest.java
@@ -1,0 +1,10 @@
+package com.depromeet.stonebed.domain.missionRecord.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record MissionRecordCalendarRequest(
+        @Schema(description = "커서 위치", example = "2024-01-01") String cursor,
+        @Schema(description = "페이지 당 항목 수", example = "30") @NotNull @Min(1) int limit,
+        @Schema(description = "조회할 memberId", example = "1") Long memberId) {}

--- a/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
+++ b/src/main/java/com/depromeet/stonebed/global/error/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     MISSION_HISTORY_NOT_FOUNT(HttpStatus.NOT_FOUND, "해당 일별 미션 정보를 찾을 수 없습니다."),
     MISSION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미션 기록을 찾을 수 없습니다."),
     NO_AVAILABLE_TODAY_MISSION(HttpStatus.INTERNAL_SERVER_ERROR, "할당 가능한 오늘의 미션이 없습니다."),
+    DUPLICATE_MISSION_RECORD(HttpStatus.BAD_REQUEST, "오늘 완료한 미션이 존재합니다."),
 
     // image
     IMAGE_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이미지를 찾을 수 없습니다."),

--- a/src/test/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordServiceTest.java
@@ -15,6 +15,7 @@ import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordRepository;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordBoost;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordStatus;
+import com.depromeet.stonebed.domain.missionRecord.dto.request.MissionRecordCalendarRequest;
 import com.depromeet.stonebed.domain.missionRecord.dto.response.MissionRecordCalendarResponse;
 import com.depromeet.stonebed.domain.missionRecord.dto.response.MissionRecordCompleteTotal;
 import com.depromeet.stonebed.domain.missionRecord.dto.response.MissionTabResponse;
@@ -132,10 +133,13 @@ class MissionRecordServiceTest extends FixtureMonkeySetUp {
         String cursor = null;
         int limit = 5;
 
+        MissionRecordCalendarRequest request =
+                new MissionRecordCalendarRequest(cursor, limit, null);
+
         // when
         MissionRecordCalendarResponse response =
                 missionRecordService.getMissionRecordsForCalendar(
-                        cursor, limit, null); // Pass null for memberId
+                        request); // Pass null for memberId
 
         // then
         then(response).isNotNull();
@@ -160,9 +164,12 @@ class MissionRecordServiceTest extends FixtureMonkeySetUp {
         String cursor = null;
         int limit = 5;
 
+        MissionRecordCalendarRequest request =
+                new MissionRecordCalendarRequest(cursor, limit, member.getId());
+
         // when
         MissionRecordCalendarResponse response =
-                missionRecordService.getMissionRecordsForCalendar(cursor, limit, member.getId());
+                missionRecordService.getMissionRecordsForCalendar(request);
 
         // then
         then(response).isNotNull();


### PR DESCRIPTION
## 🌱 관련 이슈
- close #229 

## 📌 작업 내용
- 미션이 COMPLETED인 상태 기록만 불러오는 조건 추가
- 컨트롤러 파라미터 컨벤션 조정
- 같은 날 여러개의 데이터가 존재하는 엣지케이스 방지 위해 미션 기록 저장 시 방어 로직 추가

## 🙏 리뷰 요구사항
- 같은 날 여러개의 데이터가 존재할 때 최근꺼를 가져오는 것 보다, 처음부터 미션 기록이 저장 될 때 같은 날 2개 이상의 데이터가 저장되지 않게 막아놨습니다.

## 📚 레퍼런스
- 
