### PR TITLE
미션 기록 캘린더 COMPLETED인 데이터만 조회

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordService.java
@@ -87,9 +87,10 @@ public class MissionRecordService {
 
         LocalDate today = LocalDate.now();
         boolean recordExists =
-                missionRecordRepository.existsByMemberAndMissionHistoryAndCreatedAtBetween(
+                missionRecordRepository.existsByMemberAndMissionHistoryAndStatusAndCreatedAtBetween(
                         member,
                         missionHistory,
+                        MissionRecordStatus.COMPLETED,
                         today.atStartOfDay(),
                         today.plusDays(1).atStartOfDay());
 

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepository.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dao/MissionRecordRepository.java
@@ -24,11 +24,12 @@ public interface MissionRecordRepository
 
     List<MissionRecord> findByIdIn(List<Long> ids);
 
-    boolean existsByMemberAndMissionHistoryAndCreatedAtBetween(
+    boolean existsByMemberAndMissionHistoryAndStatusAndCreatedAtBetween(
             Member member,
             MissionHistory missionHistory,
-            LocalDateTime startOfDay,
-            LocalDateTime endOfDay);
+            MissionRecordStatus status,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime);
 
     @Modifying
     @Query(


### PR DESCRIPTION
## 🌱 관련 이슈
- close #232 

## 📌 작업 내용
- 현재 COMPLETED가 아닌 상태에도 미션 기록 중복 저장 에러 발생하고있어서 COMPLETED일 때만 안되게 수정

## 🙏 리뷰 요구사항
-

## 📚 레퍼런스
- 
