### PR TITLE
feat: 미션 완료 카드 Response 필드 추가

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/feed/dao/FeedRepositoryImpl.java
+++ b/src/main/java/com/depromeet/stonebed/domain/feed/dao/FeedRepositoryImpl.java
@@ -47,7 +47,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                         ltMissionRecordId(missionRecordId),
                         eqMemberId(memberId))
                 .groupBy(missionRecord.id)
-                .orderBy(missionRecord.id.desc());
+                .orderBy(missionRecord.updatedAt.desc());
     }
 
     @Override

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordService.java
@@ -219,7 +219,14 @@ public class MissionRecordService {
                         .orElse(null);
 
         if (missionRecord == null) {
-            return MissionTabResponse.of(null, MissionRecordStatus.NOT_COMPLETED);
+            return MissionTabResponse.of(
+                    null,
+                    null,
+                    MissionRecordStatus.NOT_COMPLETED,
+                    mission.getTitle(),
+                    mission.getIllustrationUrl(),
+                    null,
+                    null);
         }
 
         MissionRecordStatus missionRecordStatus = missionRecord.getStatus();
@@ -228,7 +235,14 @@ public class MissionRecordService {
                         ? missionRecord.getImageUrl()
                         : null;
 
-        return MissionTabResponse.of(imageUrl, missionRecordStatus);
+        return MissionTabResponse.of(
+                missionRecord.getId(),
+                imageUrl,
+                missionRecordStatus,
+                mission.getTitle(),
+                mission.getIllustrationUrl(),
+                missionRecord.getContent(),
+                missionRecord.getUpdatedAt().toLocalDate());
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/dto/response/MissionTabResponse.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/dto/response/MissionTabResponse.java
@@ -2,12 +2,26 @@ package com.depromeet.stonebed.domain.missionRecord.dto.response;
 
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecordStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
 
 public record MissionTabResponse(
+        @Schema(description = "기록 ID", example = "1") Long recordId,
         @Schema(description = "이미지 URL", example = "example.jpeg") String imageUrl,
-        @Schema(description = "미션 상태", example = "NOT_COMPLETED") MissionRecordStatus status) {
+        @Schema(description = "미션 상태", example = "NOT_COMPLETED") MissionRecordStatus status,
+        @Schema(description = "미션 제목", example = "산책하기") String missionTitle,
+        @Schema(description = "미션 일러스트 이미지", example = "example.jpeg") String illustrationUrl,
+        @Schema(description = "기록 내용", example = "오늘 마실다녀왔어요") String content,
+        @Schema(description = "완료 일자", example = "2021-10-10") LocalDate completedAt) {
 
-    public static MissionTabResponse of(String imageUrl, MissionRecordStatus status) {
-        return new MissionTabResponse(imageUrl, status);
+    public static MissionTabResponse of(
+            Long recordId,
+            String imageUrl,
+            MissionRecordStatus status,
+            String missionTitle,
+            String illustrationUrl,
+            String content,
+            LocalDate completedAt) {
+        return new MissionTabResponse(
+                recordId, imageUrl, status, missionTitle, illustrationUrl, content, completedAt);
     }
 }

--- a/src/test/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/missionRecord/application/MissionRecordServiceTest.java
@@ -315,6 +315,9 @@ class MissionRecordServiceTest extends FixtureMonkeySetUp {
         then(response).isNotNull();
         then(response.imageUrl()).isEqualTo(missionRecord.getImageUrl());
         then(response.status()).isEqualTo(MissionRecordStatus.COMPLETED);
+        then(response.recordId()).isEqualTo(missionRecord.getId());
+        then(response.completedAt()).isEqualTo(missionRecord.getUpdatedAt().toLocalDate());
+        then(response.content()).isEqualTo(missionRecord.getContent());
 
         verify(memberUtil).getCurrentMember();
         verify(missionRepository).findById(missionId);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #254 

## 📌 작업 내용
- 미션 완료에 대한 Response 필드 추가
- 필드 추가 사항
 - 미션 명
 - 미션 일러스트 이미지 url
 - 미션 기록 내용
 - 미션 완료 일자(LocalDate)

## 🙏 리뷰 요구사항
- 잠수함 패치로 피드에 대한 정렬을 updatedAt 기준으로 변경

## 📚 레퍼런스
- 
