### PR TITLE
Fcm 메세지에 deepLink 페이로드 설정

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationService.java
@@ -186,11 +186,16 @@ public class FcmNotificationService {
                         .map(FcmToken::getToken)
                         .orElseThrow(() -> new CustomException(ErrorCode.FAILED_TO_FIND_FCM_TOKEN));
 
+        String deepLink =
+                FcmNotification.generateDeepLink(
+                        FcmNotificationType.BOOSTER, missionRecord.getId());
+
         FcmMessage fcmMessage =
                 FcmMessage.of(
                         notificationConstants.getTitle(),
                         notificationConstants.getMessage(),
-                        token);
+                        token,
+                        deepLink);
         sqsMessageService.sendMessage(fcmMessage);
 
         saveNotification(
@@ -237,8 +242,10 @@ public class FcmNotificationService {
     public void sendAndNotifications(String title, String message, List<String> tokens) {
         List<List<String>> batches = createBatches(tokens, 10);
 
+        String deepLink = FcmNotification.generateDeepLink(FcmNotificationType.MISSION, null);
+
         for (List<String> batch : batches) {
-            sqsMessageService.sendBatchMessages(batch, title, message);
+            sqsMessageService.sendBatchMessages(batch, title, message, deepLink);
         }
 
         List<FcmNotification> notifications = buildNotificationList(title, message, tokens);

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmMessage.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmMessage.java
@@ -1,8 +1,8 @@
 package com.depromeet.stonebed.domain.fcm.domain;
 
-public record FcmMessage(String title, String body, String token) {
+public record FcmMessage(String title, String body, String token, String deepLink) {
 
-    public static FcmMessage of(String title, String body, String token) {
-        return new FcmMessage(title, body, token);
+    public static FcmMessage of(String title, String body, String token, String deepLink) {
+        return new FcmMessage(title, body, token, deepLink);
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
@@ -39,6 +39,8 @@ public class FcmNotification extends BaseTimeEntity {
     @Schema(description = "딥링크 URL", example = "myapp://notification/1")
     private String deepLink;
 
+    private static final String DEEP_LINK_PREFIX = "myapp://";
+
     private FcmNotification(
             FcmNotificationType type,
             String title,
@@ -71,11 +73,11 @@ public class FcmNotification extends BaseTimeEntity {
         this.isRead = true;
     }
 
-    private static String generateDeepLink(FcmNotificationType type, Long targetId) {
+    public static String generateDeepLink(FcmNotificationType type, Long targetId) {
         if (type == FcmNotificationType.MISSION) {
-            return "myapp://mission";
+            return DEEP_LINK_PREFIX + "mission";
         } else if (type == FcmNotificationType.BOOSTER) {
-            return "myapp://boost?id=" + targetId;
+            return DEEP_LINK_PREFIX + "boost?id=" + targetId;
         }
         return null;
     }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotification.java
@@ -47,15 +47,13 @@ public class FcmNotification extends BaseTimeEntity {
             String message,
             Member member,
             Long targetId,
-            Boolean isRead,
-            String deepLink) {
+            Boolean isRead) {
         this.type = type;
         this.title = title;
         this.message = message;
         this.member = member;
         this.targetId = targetId;
         this.isRead = isRead;
-        this.deepLink = deepLink;
     }
 
     public static FcmNotification create(
@@ -65,8 +63,7 @@ public class FcmNotification extends BaseTimeEntity {
             Member member,
             Long targetId,
             Boolean isRead) {
-        String deepLink = generateDeepLink(type, targetId);
-        return new FcmNotification(type, title, message, member, targetId, isRead, deepLink);
+        return new FcmNotification(type, title, message, member, targetId, isRead);
     }
 
     public void markAsRead() {

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationDto.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/dto/response/FcmNotificationDto.java
@@ -15,8 +15,8 @@ public record FcmNotificationDto(
                 String imageUrl,
         @Schema(description = "읽음 여부", example = "false") Boolean isRead,
         @Schema(description = "타겟 ID", example = "1") Long targetId,
-        @Schema(description = "알림 전송 시간", example = "2024-08-17 13:31:19") LocalDateTime createdAt,
-        @Schema(description = "딥링크 URL", example = "myapp://notification/1") String deepLink) {
+        @Schema(description = "알림 전송 시간", example = "2024-08-17 13:31:19")
+                LocalDateTime createdAt) {
 
     public static FcmNotificationDto from(
             FcmNotification notification, MissionRecord missionRecord) {
@@ -30,7 +30,6 @@ public record FcmNotificationDto(
                 imageUrl,
                 notification.getIsRead(),
                 notification.getTargetId(),
-                notification.getCreatedAt(),
-                notification.getDeepLink());
+                notification.getCreatedAt());
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/sqs/application/SqsMessageService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/sqs/application/SqsMessageService.java
@@ -46,11 +46,12 @@ public class SqsMessageService {
         }
     }
 
-    public void sendBatchMessages(List<String> tokens, String title, String message) {
+    public void sendBatchMessages(
+            List<String> tokens, String title, String message, String deepLink) {
         List<SendMessageBatchRequestEntry> entries = new ArrayList<>();
         for (String token : tokens) {
             try {
-                FcmMessage fcmMessage = FcmMessage.of(title, message, token);
+                FcmMessage fcmMessage = FcmMessage.of(title, message, token, deepLink);
                 String messageBody = objectMapper.writeValueAsString(fcmMessage);
                 SendMessageBatchRequestEntry entry =
                         SendMessageBatchRequestEntry.builder()


### PR DESCRIPTION
## 🌱 관련 이슈
- close #256 

## 📌 작업 내용
- 기존에는 dto를 통해 deepLink를 제공해서 이동되어야하는 줄 알았는데, dto에서 제거하고 FcmMessage에 포함시켜 푸시알림에서 해당 게시글로 이동되게 수정

## 🙏 리뷰 요구사항
-

## 📚 레퍼런스
- 
