### PR TITLE
feat: 댓글 생성 시 푸시 알림

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/comment/application/CommentService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/comment/application/CommentService.java
@@ -40,126 +40,121 @@ public class CommentService {
     private final FcmTokenRepository fcmTokenRepository;
     private static final Long ROOT_COMMENT_PARENT_ID = -1L;
 
-    /**
-     * 댓글을 생성합니다.
-     *
-     * @param request 댓글 생성 요청 객체 (content, recordId, parentId 포함)
-     * @return 생성된 댓글의 ID를 포함한 응답 객체
-     */
     public CommentCreateResponse createComment(CommentCreateRequest request) {
         final Member member = memberUtil.getCurrentMember();
         final MissionRecord missionRecord = findMissionRecordById(request.recordId());
 
-        if (request.parentId() == null) {
-            final FcmNotificationConstants commentNotification = FcmNotificationConstants.COMMENT;
+        final Comment comment = createAndSaveComment(request, member, missionRecord);
+        final FcmNotificationConstants notificationType = getNotificationType(request);
 
-            final Comment comment =
-                    Comment.createComment(missionRecord, member, request.content(), null);
-            Comment savedComment = commentRepository.save(comment);
+        sendCommentNotification(missionRecord, comment, notificationType);
+        return CommentCreateResponse.of(comment.getId());
+    }
 
-            sendCommentNotification(missionRecord, comment, commentNotification);
-            return CommentCreateResponse.of(savedComment.getId());
-        } else {
-            final FcmNotificationConstants reCommentNotification =
-                    FcmNotificationConstants.RE_COMMENT;
+    private Comment createAndSaveComment(
+            CommentCreateRequest request, Member member, MissionRecord missionRecord) {
+        final Comment comment =
+                request.parentId() != null
+                        ? Comment.createComment(
+                                missionRecord,
+                                member,
+                                request.content(),
+                                findCommentById(request.parentId()))
+                        : Comment.createComment(missionRecord, member, request.content(), null);
 
-            final Comment reComment =
-                    Comment.createComment(
-                            missionRecord,
-                            member,
-                            request.content(),
-                            findCommentById(request.parentId()));
-            Comment savedComment = commentRepository.save(reComment);
+        return commentRepository.save(comment);
+    }
 
-            sendCommentNotification(missionRecord, reComment, reCommentNotification);
-            return CommentCreateResponse.of(savedComment.getId());
-        }
+    private FcmNotificationConstants getNotificationType(CommentCreateRequest request) {
+        return request.parentId() == null
+                ? FcmNotificationConstants.COMMENT
+                : FcmNotificationConstants.RE_COMMENT;
     }
 
     private void sendCommentNotification(
             MissionRecord missionRecord,
             Comment comment,
             FcmNotificationConstants commentNotification) {
-        // Set to collect unique members who should receive notifications
-        Set<Member> notificationRecipients = new HashSet<>();
+        Set<Member> notificationRecipients = collectNotificationRecipients(missionRecord, comment);
+        List<String> tokens = retrieveFcmTokens(notificationRecipients);
 
-        // Add the mission record owner
-        notificationRecipients.add(missionRecord.getMember());
-
-        // Add the parent comment writer if exists
-        Comment currentComment = comment;
-        while (currentComment.getParent() != null) {
-            currentComment = currentComment.getParent();
-            notificationRecipients.add(currentComment.getWriter());
-        }
-
-        // Retrieve FCM tokens for all unique members
-        List<String> tokens =
-                notificationRecipients.stream()
-                        .map(fcmTokenRepository::findByMember)
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
-                        .map(FcmToken::getToken)
-                        .filter(Objects::nonNull)
-                        .filter(token -> !token.isEmpty() && !token.isBlank())
-                        .collect(Collectors.toList());
-
-        // Send notifications
+        FcmNotificationType fcmNotificationType = getFcmNotificationType(commentNotification);
         fcmNotificationService.sendAndNotifications(
                 commentNotification.getTitle(),
                 commentNotification.getMessage(),
                 tokens,
-                FcmNotificationType.COMMENT);
+                fcmNotificationType);
     }
 
-    /**
-     * 특정 기록 ID에 대한 모든 댓글을 조회합니다.
-     *
-     * @param recordId 조회할 기록의 ID
-     * @return 조회된 댓글 목록을 포함한 응답 객체
-     */
+    private Set<Member> collectNotificationRecipients(
+            MissionRecord missionRecord, Comment comment) {
+        Set<Member> notificationRecipients = new HashSet<>();
+        notificationRecipients.add(missionRecord.getMember());
+
+        Comment currentComment = comment;
+        while (currentComment.getParent() != null) {
+            currentComment = currentComment.getParent();
+            currentComment.getReplyComments().stream()
+                    .map(Comment::getWriter)
+                    .forEach(notificationRecipients::add);
+        }
+        notificationRecipients.remove(comment.getWriter());
+        return notificationRecipients;
+    }
+
+    private List<String> retrieveFcmTokens(Set<Member> notificationRecipients) {
+        return notificationRecipients.stream()
+                .map(fcmTokenRepository::findByMember)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(FcmToken::getToken)
+                .filter(Objects::nonNull)
+                .filter(token -> !token.isEmpty() && !token.isBlank())
+                .collect(Collectors.toList());
+    }
+
+    private FcmNotificationType getFcmNotificationType(
+            FcmNotificationConstants commentNotification) {
+        return FcmNotificationConstants.RE_COMMENT.equals(commentNotification)
+                ? FcmNotificationType.RE_COMMENT
+                : FcmNotificationType.COMMENT;
+    }
+
     @Transactional(readOnly = true)
     public CommentFindResponse findCommentsByRecordId(Long recordId) {
         final MissionRecord missionRecord = findMissionRecordById(recordId);
         final List<Comment> allComments =
                 commentRepository.findAllCommentsByMissionRecord(missionRecord);
 
-        // 댓글을 부모 ID로 그룹화, 부모 ID가 null인 경우 -1L로 처리
-        Map<Long, List<Comment>> commentsByParentId =
-                allComments.stream()
-                        .collect(
-                                Collectors.groupingBy(
-                                        comment -> {
-                                            Comment parent = comment.getParent();
-                                            return (parent != null)
-                                                    ? parent.getId()
-                                                    : ROOT_COMMENT_PARENT_ID;
-                                        },
-                                        Collectors.toList()));
-
-        // 부모 댓글 (부모 댓글이 없는 댓글) 조회
-        List<Comment> rootComments =
-                commentsByParentId.getOrDefault(ROOT_COMMENT_PARENT_ID, List.of());
-
-        // 부모 댓글을 CommentFindOneResponse로 변환
+        Map<Long, List<Comment>> commentsByParentId = groupCommentsByParentId(allComments);
         List<CommentFindOneResponse> rootResponses =
-                rootComments.stream()
-                        .map(
-                                comment ->
-                                        convertToCommentFindOneResponse(
-                                                comment, commentsByParentId))
-                        .collect(Collectors.toList());
+                convertToCommentFindOneResponses(commentsByParentId);
 
         return CommentFindResponse.of(rootResponses);
     }
 
-    /**
-     * Comment 객체를 CommentFindOneResponse 객체로 변환합니다.
-     *
-     * @param comment 변환할 댓글 객체
-     * @param commentsByParentId 부모 ID로 그룹화된 댓글 key-value 형태의 Map
-     * @return 변환된 댓글 응답 객체
-     */
+    private Map<Long, List<Comment>> groupCommentsByParentId(List<Comment> allComments) {
+        return allComments.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                comment -> {
+                                    Comment parent = comment.getParent();
+                                    return (parent != null)
+                                            ? parent.getId()
+                                            : ROOT_COMMENT_PARENT_ID;
+                                },
+                                Collectors.toList()));
+    }
+
+    private List<CommentFindOneResponse> convertToCommentFindOneResponses(
+            Map<Long, List<Comment>> commentsByParentId) {
+        List<Comment> rootComments =
+                commentsByParentId.getOrDefault(ROOT_COMMENT_PARENT_ID, List.of());
+        return rootComments.stream()
+                .map(comment -> convertToCommentFindOneResponse(comment, commentsByParentId))
+                .collect(Collectors.toList());
+    }
+
     private CommentFindOneResponse convertToCommentFindOneResponse(
             Comment comment, Map<Long, List<Comment>> commentsByParentId) {
         List<CommentFindOneResponse> replyCommentsResponses =
@@ -181,26 +176,12 @@ public class CommentService {
                 replyCommentsResponses);
     }
 
-    /**
-     * MissionRecord를 조회
-     *
-     * @param recordId 조회할 기록의 ID
-     * @return 조회된 MissionRecord 객체
-     * @throws CustomException 기록을 찾을 수 없는 경우 예외 발생
-     */
     private MissionRecord findMissionRecordById(Long recordId) {
         return missionRecordRepository
                 .findById(recordId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MISSION_RECORD_NOT_FOUND));
     }
 
-    /**
-     * Comment를 조회
-     *
-     * @param commentId 조회할 댓글의 ID
-     * @return 조회된 Comment 객체
-     * @throws CustomException 댓글을 찾을 수 없는 경우 예외 발생
-     */
     private Comment findCommentById(Long commentId) {
         return commentRepository
                 .findById(commentId)

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationService.java
@@ -271,10 +271,14 @@ public class FcmNotificationService {
         return notifications;
     }
 
-    public void sendAndNotifications(String title, String message, List<String> tokens) {
+    public void sendAndNotifications(
+            String title,
+            String message,
+            List<String> tokens,
+            FcmNotificationType notificationType) {
         List<List<String>> batches = createBatches(tokens, BATCH_SIZE);
 
-        String deepLink = FcmNotification.generateDeepLink(FcmNotificationType.MISSION, null, null);
+        String deepLink = FcmNotification.generateDeepLink(notificationType, null, null);
 
         for (List<String> batch : batches) {
             sqsMessageService.sendBatchMessages(batch, title, message, deepLink);

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/application/FcmNotificationService.java
@@ -251,7 +251,10 @@ public class FcmNotificationService {
     }
 
     private List<FcmNotification> buildNotificationList(
-            String title, String message, List<String> tokens) {
+            String title,
+            String message,
+            List<String> tokens,
+            FcmNotificationType notificationType) {
         List<FcmNotification> notifications = new ArrayList<>();
 
         for (String token : tokens) {
@@ -263,8 +266,7 @@ public class FcmNotificationService {
                                     () -> new CustomException(ErrorCode.FAILED_TO_FIND_FCM_TOKEN));
 
             FcmNotification newNotification =
-                    FcmNotification.create(
-                            FcmNotificationType.MISSION, title, message, member, null, false);
+                    FcmNotification.create(notificationType, title, message, member, null, false);
             notifications.add(newNotification);
         }
 
@@ -284,7 +286,8 @@ public class FcmNotificationService {
             sqsMessageService.sendBatchMessages(batch, title, message, deepLink);
         }
 
-        List<FcmNotification> notifications = buildNotificationList(title, message, tokens);
+        List<FcmNotification> notifications =
+                buildNotificationList(title, message, tokens, notificationType);
         notificationRepository.saveAll(notifications);
     }
 

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotificationType.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotificationType.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum FcmNotificationType {
     MISSION("미션 알림"),
-    BOOSTER("부스터 알림");
+    BOOSTER("부스터 알림"),
+    COMMENT("댓글 알림"),
+    ;
 
     private final String value;
 }

--- a/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotificationType.java
+++ b/src/main/java/com/depromeet/stonebed/domain/fcm/domain/FcmNotificationType.java
@@ -9,6 +9,7 @@ public enum FcmNotificationType {
     MISSION("미션 알림"),
     BOOSTER("부스터 알림"),
     COMMENT("댓글 알림"),
+    RE_COMMENT("대댓글 알림"),
     ;
 
     private final String value;

--- a/src/main/java/com/depromeet/stonebed/global/common/constants/FcmNotificationConstants.java
+++ b/src/main/java/com/depromeet/stonebed/global/common/constants/FcmNotificationConstants.java
@@ -13,6 +13,7 @@ public enum FcmNotificationConstants {
     MISSION_START("미션 시작!", "새로운 미션을 지금 시작해보세요!"),
     MISSION_REMINDER("미션 리마인드", "미션 종료까지 5시간 남았어요!"),
     COMMENT("댓글 알림", "내 기록에 댓글이 달렸어요!"),
+    RE_COMMENT("대댓글 알림", "내 댓글에 답글이 달렸어요!"),
     ;
 
     private final String title;

--- a/src/main/java/com/depromeet/stonebed/global/common/constants/FcmNotificationConstants.java
+++ b/src/main/java/com/depromeet/stonebed/global/common/constants/FcmNotificationConstants.java
@@ -11,7 +11,9 @@ public enum FcmNotificationConstants {
     POPULAR("인기쟁이", "부스터를 1000개를 달성했어요!"),
     SUPER_POPULAR("최고 인기 달성", "인기폭발! 부스터를 5000개 달성했어요!"),
     MISSION_START("미션 시작!", "새로운 미션을 지금 시작해보세요!"),
-    MISSION_REMINDER("미션 리마인드", "미션 종료까지 5시간 남았어요!");
+    MISSION_REMINDER("미션 리마인드", "미션 종료까지 5시간 남았어요!"),
+    COMMENT("댓글 알림", "내 기록에 댓글이 달렸어요!"),
+    ;
 
     private final String title;
     private final String message;

--- a/src/main/java/com/depromeet/stonebed/scheduler/fcm/FcmScheduler.java
+++ b/src/main/java/com/depromeet/stonebed/scheduler/fcm/FcmScheduler.java
@@ -2,6 +2,7 @@ package com.depromeet.stonebed.scheduler.fcm;
 
 import com.depromeet.stonebed.domain.fcm.application.FcmNotificationService;
 import com.depromeet.stonebed.domain.fcm.dao.FcmTokenRepository;
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotificationType;
 import com.depromeet.stonebed.domain.fcm.domain.FcmToken;
 import com.depromeet.stonebed.domain.member.domain.MemberStatus;
 import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordRepository;
@@ -41,7 +42,8 @@ public class FcmScheduler {
         String message = notificationConstants.getMessage();
         List<String> tokens = fcmNotificationService.getAllTokens();
 
-        fcmNotificationService.sendAndNotifications(title, message, tokens);
+        fcmNotificationService.sendAndNotifications(
+                title, message, tokens, FcmNotificationType.MISSION);
 
         log.info("모든 사용자에게 정규 알림 전송 및 저장 완료");
     }
@@ -54,7 +56,8 @@ public class FcmScheduler {
         String message = notificationConstants.getMessage();
 
         List<String> tokens = getIncompleteMissionTokens();
-        fcmNotificationService.sendAndNotifications(title, message, tokens);
+        fcmNotificationService.sendAndNotifications(
+                title, message, tokens, FcmNotificationType.MISSION);
 
         log.info("미완료 미션 사용자에게 리마인더 전송 및 저장 완료. 총 토큰 수: {}", tokens.size());
     }

--- a/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmSchedulerTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/fcm/application/FcmSchedulerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.fcm.dao.FcmTokenRepository;
+import com.depromeet.stonebed.domain.fcm.domain.FcmNotificationType;
 import com.depromeet.stonebed.domain.fcm.domain.FcmToken;
 import com.depromeet.stonebed.domain.member.domain.MemberStatus;
 import com.depromeet.stonebed.domain.missionRecord.dao.MissionRecordRepository;
@@ -64,7 +65,11 @@ public class FcmSchedulerTest extends FixtureMonkeySetUp {
 
         // then
         verify(fcmNotificationService, times(1))
-                .sendAndNotifications(eq("미션 시작!"), eq("새로운 미션을 지금 시작해보세요!"), eq(tokens));
+                .sendAndNotifications(
+                        eq("미션 시작!"),
+                        eq("새로운 미션을 지금 시작해보세요!"),
+                        eq(tokens),
+                        eq(FcmNotificationType.MISSION));
     }
 
     @Test
@@ -104,6 +109,10 @@ public class FcmSchedulerTest extends FixtureMonkeySetUp {
 
         // then
         verify(fcmNotificationService, times(1))
-                .sendAndNotifications(eq("미션 리마인드"), eq("미션 종료까지 5시간 남았어요!"), eq(tokens));
+                .sendAndNotifications(
+                        eq("미션 리마인드"),
+                        eq("미션 종료까지 5시간 남았어요!"),
+                        eq(tokens),
+                        eq(FcmNotificationType.MISSION));
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #288 

## 📌 작업 내용
![image](https://github.com/user-attachments/assets/6ea989f5-afcd-4aab-9dde-40adf7a02a35)
- 댓글 생성 시 작성자에게 알림
- 대댓글 작성 시 부모 댓글 사용자, 기록 작성자에게 푸시 알림

## 🙏 리뷰 요구사항
- 기존 sendNotification에 FcmNotificationType도 인자를 받도록 재사용성 개선
- 댓글 푸시 알림은 추후 디쟌팀에게 전달받아 수정할 예정

## 📚 레퍼런스
- 
