### PR TITLE
fix: 회원 탈퇴 시 탈퇴자 댓글 예외 처리

### DIFF
--- a/src/main/java/com/depromeet/stonebed/domain/auth/application/AuthService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/auth/application/AuthService.java
@@ -8,6 +8,7 @@ import com.depromeet.stonebed.domain.auth.dto.request.RefreshTokenRequest;
 import com.depromeet.stonebed.domain.auth.dto.response.AuthTokenResponse;
 import com.depromeet.stonebed.domain.auth.dto.response.SocialClientResponse;
 import com.depromeet.stonebed.domain.auth.dto.response.TokenPairResponse;
+import com.depromeet.stonebed.domain.comment.dao.CommentRepository;
 import com.depromeet.stonebed.domain.fcm.dao.FcmNotificationRepository;
 import com.depromeet.stonebed.domain.fcm.dao.FcmTokenRepository;
 import com.depromeet.stonebed.domain.member.dao.MemberRepository;
@@ -40,6 +41,7 @@ public class AuthService {
     private final MissionRecordRepository missionRecordRepository;
     private final MissionRecordBoostRepository missionRecordBoostRepository;
     private final FcmTokenRepository fcmTokenRepository;
+    private final CommentRepository commentRepository;
 
     private final AppleClient appleClient;
     private final KakaoClient kakaoClient;
@@ -178,6 +180,7 @@ public class AuthService {
     }
 
     private void withdrawMemberRelationByMemberId(List<Long> recordIds, Long memberId) {
+        commentRepository.updateEmptyMemberAllByMember(memberId);
         missionRecordBoostRepository.deleteAllByMember(recordIds);
         missionRecordRepository.deleteAllByMember(memberId);
         fcmNotificationRepository.deleteAllByMember(memberId);

--- a/src/main/java/com/depromeet/stonebed/domain/comment/application/CommentService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/comment/application/CommentService.java
@@ -215,7 +215,7 @@ public class CommentService {
         String writerNickname =
                 comment.getWriter() != null
                         ? comment.getWriter().getProfile().getNickname()
-                        : "탈퇴한 회원입니다.";
+                        : "탈퇴한 회원";
         String writerProfileImageUrl =
                 comment.getWriter() != null
                         ? comment.getWriter().getProfile().getProfileImageUrl()

--- a/src/main/java/com/depromeet/stonebed/domain/comment/application/CommentService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/comment/application/CommentService.java
@@ -64,11 +64,12 @@ public class CommentService {
         final Comment comment =
                 request.parentId() != null
                         ? Comment.createComment(
-                                missionRecord,
+                                missionRecord.getId(),
                                 member,
                                 request.content(),
                                 findCommentById(request.parentId()))
-                        : Comment.createComment(missionRecord, member, request.content(), null);
+                        : Comment.createComment(
+                                missionRecord.getId(), member, request.content(), null);
         return commentRepository.save(comment);
     }
 
@@ -200,6 +201,7 @@ public class CommentService {
 
     private CommentFindOneResponse convertToCommentFindOneResponse(
             Comment comment, Map<Long, List<Comment>> commentsByParentId) {
+
         List<CommentFindOneResponse> replyCommentsResponses =
                 commentsByParentId.getOrDefault(comment.getId(), List.of()).stream()
                         .map(
@@ -208,13 +210,24 @@ public class CommentService {
                                                 childComment, commentsByParentId))
                         .collect(Collectors.toList());
 
+        // 작성자가 null인지 확인
+        Long writerId = comment.getWriter() != null ? comment.getWriter().getId() : null;
+        String writerNickname =
+                comment.getWriter() != null
+                        ? comment.getWriter().getProfile().getNickname()
+                        : "탈퇴한 회원입니다.";
+        String writerProfileImageUrl =
+                comment.getWriter() != null
+                        ? comment.getWriter().getProfile().getProfileImageUrl()
+                        : null;
+
         return CommentFindOneResponse.of(
                 comment.getParent() != null ? comment.getParent().getId() : null,
                 comment.getId(),
                 comment.getContent(),
-                comment.getWriter().getId(),
-                comment.getWriter().getProfile().getNickname(),
-                comment.getWriter().getProfile().getProfileImageUrl(),
+                writerId,
+                writerNickname,
+                writerProfileImageUrl,
                 comment.getCreatedAt().toString(),
                 replyCommentsResponses);
     }

--- a/src/main/java/com/depromeet/stonebed/domain/comment/dao/CommentRepositoryCustom.java
+++ b/src/main/java/com/depromeet/stonebed/domain/comment/dao/CommentRepositoryCustom.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface CommentRepositoryCustom {
     List<Comment> findAllCommentsByMissionRecord(MissionRecord missionRecord);
+
+    void updateEmptyMemberAllByMember(Long memberId);
 }

--- a/src/main/java/com/depromeet/stonebed/domain/comment/dao/CommentRepositoryImpl.java
+++ b/src/main/java/com/depromeet/stonebed/domain/comment/dao/CommentRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.depromeet.stonebed.domain.comment.dao;
 import static com.depromeet.stonebed.domain.comment.domain.QComment.comment;
 
 import com.depromeet.stonebed.domain.comment.domain.Comment;
+import com.depromeet.stonebed.domain.member.domain.Member;
 import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -21,7 +22,16 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .fetchJoin()
                 .leftJoin(comment.replyComments)
                 .fetchJoin()
-                .where(comment.missionRecord.eq(missionRecord))
+                .where(comment.recordId.eq(missionRecord.getId()))
                 .fetch();
+    }
+
+    @Override
+    public void updateEmptyMemberAllByMember(Long memberId) {
+        queryFactory
+                .update(comment)
+                .set(comment.writer, (Member) null)
+                .where(comment.writer.id.eq(memberId))
+                .execute();
     }
 }

--- a/src/main/java/com/depromeet/stonebed/domain/comment/domain/Comment.java
+++ b/src/main/java/com/depromeet/stonebed/domain/comment/domain/Comment.java
@@ -2,7 +2,6 @@ package com.depromeet.stonebed.domain.comment.domain;
 
 import com.depromeet.stonebed.domain.common.BaseTimeEntity;
 import com.depromeet.stonebed.domain.member.domain.Member;
-import com.depromeet.stonebed.domain.missionRecord.domain.MissionRecord;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
@@ -33,13 +32,13 @@ public class Comment extends BaseTimeEntity {
     @Column(name = "comment_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "record_id", nullable = false)
-    private MissionRecord missionRecord;
+    @Schema(description = "미션 기록 ID", example = "1")
+    @Column(name = "record_id", nullable = false)
+    private Long recordId;
 
     // 작성자
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "writer_id", nullable = false)
+    @JoinColumn(name = "writer_id")
     private Member writer;
 
     @Schema(description = "댓글 내용", example = "너무 이쁘자나~")
@@ -56,17 +55,17 @@ public class Comment extends BaseTimeEntity {
     private List<Comment> replyComments = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
-    public Comment(MissionRecord missionRecord, Member writer, String content, Comment parent) {
-        this.missionRecord = missionRecord;
+    public Comment(Long recordId, Member writer, String content, Comment parent) {
+        this.recordId = recordId;
         this.writer = writer;
         this.content = content;
         this.parent = parent;
     }
 
     public static Comment createComment(
-            MissionRecord missionRecord, Member writer, String content, @Nullable Comment parent) {
+            Long recordId, Member writer, String content, @Nullable Comment parent) {
         return Comment.builder()
-                .missionRecord(missionRecord)
+                .recordId(recordId)
                 .writer(writer)
                 .content(content)
                 .parent(parent)

--- a/src/main/java/com/depromeet/stonebed/domain/feed/application/FeedService.java
+++ b/src/main/java/com/depromeet/stonebed/domain/feed/application/FeedService.java
@@ -86,6 +86,7 @@ public class FeedService {
         return FeedContentGetResponse.from(feedOne);
     }
 
+    @Transactional(readOnly = true)
     public FeedGetResponseV2 findFeedV2(FeedGetRequest request) {
         List<FindFeedDto> feeds = getFeeds(request.cursor(), request.memberId(), request.limit());
 

--- a/src/main/java/com/depromeet/stonebed/domain/feed/dao/FeedRepositoryImpl.java
+++ b/src/main/java/com/depromeet/stonebed/domain/feed/dao/FeedRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.depromeet.stonebed.domain.feed.dao;
 
+import static com.depromeet.stonebed.domain.comment.domain.QComment.*;
 import static com.depromeet.stonebed.domain.member.domain.QMember.*;
 import static com.depromeet.stonebed.domain.mission.domain.QMission.*;
 import static com.depromeet.stonebed.domain.missionHistory.domain.QMissionHistory.*;
@@ -61,7 +62,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                         mission,
                         missionRecord,
                         member,
-                        Expressions.asNumber(missionRecord.comments.size()).as("totalCommentCount"),
+                        comment.id.count().as("commentCount"),
                         Expressions.asNumber(missionRecordBoost.count.sumLong().coalesce(0L))
                                 .as("totalBoostCount")));
     }
@@ -75,7 +76,9 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .leftJoin(missionHistory)
                 .on(missionRecord.missionHistory.eq(missionHistory))
                 .leftJoin(mission)
-                .on(missionHistory.mission.eq(mission));
+                .on(missionHistory.mission.eq(mission))
+                .leftJoin(comment)
+                .on(comment.recordId.eq(missionRecord.id)); // Join Comment entity
     }
 
     private BooleanExpression ltMissionRecordId(Long missionRecordId) {

--- a/src/main/java/com/depromeet/stonebed/domain/feed/dto/FindFeedDto.java
+++ b/src/main/java/com/depromeet/stonebed/domain/feed/dto/FindFeedDto.java
@@ -8,13 +8,13 @@ public record FindFeedDto(
         Mission mission,
         MissionRecord missionRecord,
         Member author,
-        Integer totalCommentCount,
+        Long totalCommentCount,
         Long totalBoostCount) {
     public static FindFeedDto from(
             Mission mission,
             MissionRecord missionRecord,
             Member author,
-            Integer totalCommentCount,
+            Long totalCommentCount,
             Long totalBoostCount) {
         return new FindFeedDto(mission, missionRecord, author, totalCommentCount, totalBoostCount);
     }

--- a/src/main/java/com/depromeet/stonebed/domain/feed/dto/response/v1/FeedContentGetResponse.java
+++ b/src/main/java/com/depromeet/stonebed/domain/feed/dto/response/v1/FeedContentGetResponse.java
@@ -17,7 +17,7 @@ public record FeedContentGetResponse(
                 String missionRecordImageUrl,
         @Schema(description = "미션 기록 생성일") LocalDate createdDate,
         @Schema(description = "부스트") Long totalBoostCount,
-        @Schema(description = "댓글 수", example = "12") Integer totalCommentCount,
+        @Schema(description = "댓글 수", example = "12") Long totalCommentCount,
         @Schema(description = "미션 기록 컨텐츠") String content) {
     public static FeedContentGetResponse from(FindFeedDto missionRecord) {
         return new FeedContentGetResponse(
@@ -29,7 +29,7 @@ public record FeedContentGetResponse(
                 missionRecord.author().getProfile().getNickname(),
                 missionRecord.author().getProfile().getProfileImageUrl(),
                 missionRecord.missionRecord().getImageUrl(),
-                missionRecord.missionRecord().getCreatedAt().toLocalDate(),
+                missionRecord.missionRecord().getUpdatedAt().toLocalDate(),
                 missionRecord.totalBoostCount(),
                 missionRecord.totalCommentCount(),
                 missionRecord.missionRecord().getContent());

--- a/src/main/java/com/depromeet/stonebed/domain/feed/dto/response/v2/FeedContentGetResponseV2.java
+++ b/src/main/java/com/depromeet/stonebed/domain/feed/dto/response/v2/FeedContentGetResponseV2.java
@@ -17,7 +17,7 @@ public record FeedContentGetResponseV2(
                 String missionRecordImageUrl,
         @Schema(description = "미션 기록 생성일") LocalDate createdDate,
         @Schema(description = "부스트") Long totalBoostCount,
-        @Schema(description = "댓글 수", example = "12") Integer totalCommentCount,
+        @Schema(description = "댓글 수", example = "12") Long totalCommentCount,
         @Schema(description = "미션 기록 컨텐츠") String content) {
     public static FeedContentGetResponseV2 from(FindFeedDto missionRecord) {
         return new FeedContentGetResponseV2(
@@ -29,7 +29,7 @@ public record FeedContentGetResponseV2(
                 missionRecord.author().getProfile().getNickname(),
                 missionRecord.author().getProfile().getProfileImageUrl(),
                 missionRecord.missionRecord().getImageUrl(),
-                missionRecord.missionRecord().getCreatedAt().toLocalDate(),
+                missionRecord.missionRecord().getUpdatedAt().toLocalDate(),
                 missionRecord.totalBoostCount(),
                 missionRecord.totalCommentCount(),
                 missionRecord.missionRecord().getContent());

--- a/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecord.java
+++ b/src/main/java/com/depromeet/stonebed/domain/missionRecord/domain/MissionRecord.java
@@ -33,7 +33,7 @@ public class MissionRecord extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToMany(mappedBy = "missionRecord", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
     @Schema(description = "미션 이미지 URL", example = "./missionRecord.jpg")

--- a/src/test/java/com/depromeet/stonebed/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/auth/application/AuthServiceTest.java
@@ -7,6 +7,7 @@ import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.auth.domain.OAuthProvider;
 import com.depromeet.stonebed.domain.auth.dto.response.AuthTokenResponse;
 import com.depromeet.stonebed.domain.auth.dto.response.TokenPairResponse;
+import com.depromeet.stonebed.domain.comment.dao.CommentRepository;
 import com.depromeet.stonebed.domain.fcm.dao.FcmNotificationRepository;
 import com.depromeet.stonebed.domain.fcm.dao.FcmTokenRepository;
 import com.depromeet.stonebed.domain.member.dao.MemberRepository;
@@ -40,6 +41,7 @@ class AuthServiceTest extends FixtureMonkeySetUp {
     @Mock private MissionRecordRepository missionRecordRepository;
     @Mock private MissionRecordBoostRepository missionRecordBoostRepository;
     @Mock private FcmTokenRepository fcmTokenRepository;
+    @Mock private CommentRepository commentRepository;
 
     @Mock private MemberUtil memberUtil;
 

--- a/src/test/java/com/depromeet/stonebed/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/comment/application/CommentServiceTest.java
@@ -2,7 +2,6 @@ package com.depromeet.stonebed.domain.comment.application;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.springframework.transaction.annotation.Isolation.*;
 
 import com.depromeet.stonebed.FixtureMonkeySetUp;
 import com.depromeet.stonebed.domain.comment.dao.CommentRepository;

--- a/src/test/java/com/depromeet/stonebed/domain/feed/application/FeedServiceTest.java
+++ b/src/test/java/com/depromeet/stonebed/domain/feed/application/FeedServiceTest.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.ActiveProfiles;
 class FeedServiceTest extends FixtureMonkeySetUp {
     int DEFAULT_LIMIT = 5;
     Long DEFAULT_TOTAL_BOOST_COUNT = 100L;
-    Integer DEFAULT_TOTAL_COMMENT_COUNT = 13;
+    Long DEFAULT_TOTAL_COMMENT_COUNT = 13L;
     String DEFAULT_CURSOR = "5";
     String INVALID_CURSOR = "2024-08-01";
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #315 

## 📌 작업 내용
- comment-record mapping에 대한 연관관계 삭제
- recordId를 저장하며 직접 proxy접근이 아니도록 수정
- 회원탈퇴 시 comment 테이블의 writerId는 null로 처리되도록 수정

## 🙏 리뷰 요구사항
-

## 📚 레퍼런스
- 
